### PR TITLE
Optimise runtimes 

### DIFF
--- a/analysisOnData/runAnalysis.py
+++ b/analysisOnData/runAnalysis.py
@@ -1,0 +1,114 @@
+import os
+import sys
+import ROOT
+import json
+import argparse
+import copy
+from RDFtree import RDFtree
+from multiprocessing import Process, cpu_count
+from runAnalysisOnMC import RDFprocessMC
+from runAnalysisOnWJetsMC import RDFprocessWJetsMC
+from runAnalysisOnData import RDFprocessData, RDFprocessfakefromData
+
+sys.path.append('python/')
+sys.path.append('data/')
+from systematics import systematics
+from selections import selections, selectionVars, selections_bkg
+from getLumiWeight import getLumiWeight
+
+ROOT.gSystem.Load('bin/libAnalysisOnData.so')
+ROOT.gROOT.ProcessLine("gErrorIgnoreLevel = 2001;");
+
+parser = argparse.ArgumentParser("")
+parser.add_argument('-p', '--pretend',type=int, default=False, help="run over a small number of event")
+parser.add_argument('-c', '--ncores',type=int, default=64, help="number of cores used")
+parser.add_argument('-o', '--outputDir',type=str, default='./output/', help="output dir name")
+parser.add_argument('-i', '--inputDir',type=str, default='/scratchssd/sroychow/NanoAOD2016-V2/', help="input dir name")
+parser.add_argument('-b', '--runBKG',type=int, default=False, help="prepare the input of the bkg analysis, if =false run the prefit Plots")
+parser.add_argument('-f', '--bkgFile',type=str, default='/scratch/bertacch/wmass/wproperties-analysis/bkgAnalysis/TEST_runTheMatrix/bkg_parameters_C\
+FstatAna.root', help="bkg parameters file path/name.root")
+args = parser.parse_args()
+pretendJob = args.pretend
+ncores = args.ncores
+outputDir = args.outputDir
+inDir = args.inputDir
+runBKG = args.runBKG
+bkgFile = args.bkgFile
+
+#in the new machine, optimal performance with 128 cores is seen.
+ncmax = cpu_count()/2 if cpu_count() > 64 else cpu_count()
+
+samples={}
+with open('data/samples_2016.json') as f:
+  samples = json.load(f)
+
+multiprocs=[]
+if runBKG : #produces templates for all regions and prefit for signal
+  for sample in samples:
+      if not samples[sample]['datatype']=='MC': continue
+      print "Sample:", sample
+      #if not samples[sample]['multiprocessing']: continue
+      #WJets to be run by a separate config
+      #if 'WJets' in sample : continue
+      print sample
+      direc = samples[sample]['dir']
+      xsec = samples[sample]['xsec']
+      cores = 0 if samples[sample]['multiprocessing'] else ncores
+      fvec=ROOT.vector('string')()
+      for dirname,fname in direc.iteritems():
+          ##check if file exists or not
+          #inputFile = '/scratchssd/sroychow/NanoAOD2016-V2/{}/tree.root'.format(dirname)
+          inputFile = '{}/{}/tree.root'.format(inDir, dirname)
+          isFile = os.path.isfile(inputFile)  
+          if not isFile:
+              print inputFile, " does not exist"
+              continue
+          fvec.push_back(inputFile)
+          print inputFile
+      if fvec.empty():
+         print "No files found for directory:", samples[sample], " SKIPPING processing"
+         continue
+      print fvec 
+      fileSF = ROOT.TFile.Open("data/ScaleFactors_OnTheFly.root")
+      systType = samples[sample]['systematics']
+
+      if 'WJets' in sample : #nc = ncpus/2
+          p = Process(target=RDFprocessWJetsMC, args=(fvec, outputDir, sample, xsec, fileSF, ncmax, pretendJob))
+          p.start()
+          multiprocs.append(p)
+      else:
+          p = Process(target=RDFprocessMC, args=(fvec, outputDir, sample, xsec, fileSF, cores, systType, pretendJob))	
+          p.start()
+          multiprocs.append(p)
+
+
+###For Data
+print "Sample:DATA"
+fvec=ROOT.vector('string')()
+for sample in samples:
+    if not samples[sample]['datatype']=='DATA': continue
+    direc = samples[sample]['dir']
+    for dirname,fname in direc.iteritems():
+     #inputFile = '/scratchssd/sroychow/NanoAOD2016-V2/{}/tree.root'.format(dirname)   
+        inputFile = '{}/{}/tree.root'.format(inDir, dirname)
+        isFile = os.path.isfile(inputFile)
+        if not isFile:
+            print inputFile, " does not exist"
+            continue
+        fvec.push_back(inputFile)
+if fvec.empty():
+    print "No files found for json provided\n"
+    sys.exit(1)
+print fvec
+if runBKG : #produces templates for all regions and prefit for signal
+    p = Process(target=RDFprocessData, args=(fvec, outputDir, ncmax, pretendJob))
+    p.start()
+    multiprocs.append(p)
+else : #produces Fake contribution to prefit plots computed from data
+    p = Process(target=RDFprocessfakefromData, args=(fvec, outputDir, bkgFile, ncmax, pretendJob))
+    p.start()
+    multiprocs.append(p)
+
+for p in multiprocs:  
+    #p.start()
+    p.join()

--- a/analysisOnData/runAnalysisOnData.py
+++ b/analysisOnData/runAnalysisOnData.py
@@ -8,61 +8,15 @@ from RDFtree import RDFtree
 sys.path.append('python/')
 sys.path.append('data/')
 from systematics import systematics
-
 from selections import selections, selections_bkg, selections_fakes, selectionVars
 from getLumiWeight import getLumiWeight
-
 ROOT.gSystem.Load('bin/libAnalysisOnData.so')
 
-parser = argparse.ArgumentParser("")
-parser.add_argument('-pretend', '--pretend',type=int, default=False, help="run over a small number of event")
-parser.add_argument('-runBKG', '--runBKG',type=int, default=False, help="prepare the input of the bkg analysis, if =false run the prefit Plots")
-parser.add_argument('-ncores', '--ncores',type=int, default=64, help="number of cores used")
-parser.add_argument('-outputDir', '--outputDir',type=str, default='./output/', help="output dir name")
-parser.add_argument('-bkgFile', '--bkgFile',type=str, default='/scratch/bertacch/wmass/wproperties-analysis/bkgAnalysis/TEST_runTheMatrix/bkg_parameters_CFstatAna.root', help="bkg parameters file path/name.root")
-
-args = parser.parse_args()
-pretendJob = args.pretend
-runBKG = args.runBKG
-ncores = args.ncores
-outputDir = args.outputDir
-bkgFile = args.bkgFile
-
-if pretendJob:
-    print "Running a test job over a few events"
-else:
-    print "Running on full dataset"
-
-outF="SingleMuonData_plots.root"
-
-fvec=ROOT.vector('string')()
-
-samples={}
-with open('data/samples_2016.json') as f:
-  samples = json.load(f)
-for sample in samples:
-    if not samples[sample]['datatype']=='DATA': continue
-    #print sample
-    direc = samples[sample]['dir']
-    for dirname,fname in direc.iteritems():
-        ##check if file exists or not
-        inputFile = '/scratchssd/sroychow/NanoAOD2016-V2/{}/tree.root'.format(dirname)
-        isFile = os.path.isfile(inputFile)  
-        if not isFile:
-            print inputFile, " does not exist"
-            continue
-        fvec.push_back(inputFile)
-        #print inputFile
-
-if fvec.empty():
-    print "No files found for json provided\n"
-    sys.exit(1)
-    
-print fvec
-ROOT.ROOT.EnableImplicitMT(ncores)
-print "running with {} cores".format(ncores)
-weight = 'float(1)'
-if runBKG : #produces templates for all regions and prefit for signal
+#produces templates for all regions and prefit for signal
+def RDFprocessData(fvec, outputDir, ncores, pretendJob=True, outF="SingleMuonData_plots.root"):
+    ROOT.ROOT.EnableImplicitMT(ncores)
+    print "running with {} cores".format(ncores)
+    weight = 'float(1)'
     outF="SingleMuonData_plots.root"
     p = RDFtree(outputDir = outputDir, inputFile = fvec, outputFile=outF, pretend=pretendJob)
     p.branch(nodeToStart = 'input', nodeToEnd = 'defs', modules = [ROOT.baseDefinitions(0)])
@@ -78,8 +32,12 @@ if runBKG : #produces templates for all regions and prefit for signal
         p.branch(nodeToStart = 'defs', nodeToEnd = 'templates_{}/Nominal'.format(region), modules = [ROOT.templates(cut, weight, nom,"Nom",0)])       
     p.getOutput()
     p.saveGraph()
-else : #produces Fake contribution to prefit plots computed from data 
-    outF="FakeFromData_plots.root"
+
+#produces Fake contribution to prefit plots computed from data 
+def RDFprocessfakefromData(fvec, outputDir, bkgFile, ncores, pretendJob=True, outF="FakeFromData_plots.root"):
+    ROOT.ROOT.EnableImplicitMT(ncores)
+    print "running with {} cores".format(ncores)
+    weight = 'float(1)'
     #in case we want pdf variations for fakes
     #systematics.update({ "LHEPdfWeight" : ( ["_LHEPdfWeight" + str(i)  for i in range(0, 100)], "LHEPdfWeight" ) } )
     print systematics
@@ -122,5 +80,50 @@ else : #produces Fake contribution to prefit plots computed from data
     p.getOutput()
     p.saveGraph()
 
+def main():
+    parser = argparse.ArgumentParser("")
+    parser.add_argument('-p', '--pretend',type=int, default=False, help="run over a small number of event")
+    parser.add_argument('-b', '--runBKG',type=int, default=False, help="prepare the input of the bkg analysis, if =false run the prefit Plots")
+    parser.add_argument('-c', '--ncores',type=int, default=64, help="number of cores used")
+    parser.add_argument('-o', '--outputDir',type=str, default='./output/', help="output dir name")
+    parser.add_argument('-f', '--bkgFile',type=str, default='/scratch/bertacch/wmass/wproperties-analysis/bkgAnalysis/TEST_runTheMatrix/bkg_parameters_CFstatAna.root', help="bkg parameters file path/name.root")
+    parser.add_argument('-i', '--inputDir',type=str, default='/scratchssd/sroychow/NanoAOD2016-V2/', help="input dir name")
 
+    args = parser.parse_args()
+    pretendJob = args.pretend
+    runBKG = args.runBKG
+    ncores = args.ncores
+    outputDir = args.outputDir
+    bkgFile = args.bkgFile
+    inDir = args.inputDir
+    if pretendJob:
+        print "Running a test job over a few events"
+    else:
+        print "Running on full dataset"
+    fvec=ROOT.vector('string')()
+    samples={}
+    with open('data/samples_2016.json') as f:
+        samples = json.load(f)
+    for sample in samples:
+        if not samples[sample]['datatype']=='DATA': continue
+        direc = samples[sample]['dir']
+        for dirname,fname in direc.iteritems():
+            ##check if file exists or not
+            inputFile = '{}/{}/tree.root'.format(inDir, dirname)
+            isFile = os.path.isfile(inputFile)  
+            if not isFile:
+                print inputFile, " does not exist"
+                continue
+            fvec.push_back(inputFile)
+        
+    if fvec.empty():
+        print "No files found for json provided\n"
+        sys.exit(1)
+    print fvec
+    if runBKG : #produces templates for all regions and prefit for signal
+        RDFprocessData(fvec, outputDir, ncores, pretendJob)
+    else : #produces Fake contribution to prefit plots computed from data 
+        RDFprocessfakefromData(fvec, outputDir, bkgFile, ncores, pretendJob)
 
+if __name__ == "__main__":
+    main()

--- a/analysisOnData/runAnalysisOnWJetsMC.py
+++ b/analysisOnData/runAnalysisOnWJetsMC.py
@@ -15,132 +15,136 @@ from getLumiWeight import getLumiWeight
 ROOT.gSystem.Load('bin/libAnalysisOnData.so')
 ROOT.gROOT.ProcessLine("gErrorIgnoreLevel = 2001;");
 
-parser = argparse.ArgumentParser("")
-parser.add_argument('-pretend', '--pretend',type=int, default=False, help="run over a small number of event")
-parser.add_argument('-ncores', '--ncores',type=int, default=64, help="number of cores used")
-parser.add_argument('-outputDir', '--outputDir',type=str, default='./output/', help="output dir name")
+def RDFprocessWJetsMC(fvec, outputDir, sample, xsec, fileSF, ncores, pretendJob=True):
+    ROOT.ROOT.EnableImplicitMT(ncores)
+    print "running with {} cores for sample:{}".format(ncores, sample) 
+    wdecayselections = { 
+        'WToMu'  : ' && (abs(genVtype) == 14)',
+        'WToTau' : ' && (abs(genVtype) == 16)'
+    }
 
-args = parser.parse_args()
-pretendJob = args.pretend
-ncores = args.ncores
-outputDir = args.outputDir
-if pretendJob:
-    print "Running a test job over a few events"
-else:
-    print "Running on full dataset"
-
-samples={}
-with open('data/samples_2016.json') as f:
-  samples = json.load(f)
-
-sample='WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8'
-print sample
-direc = samples[sample]['dir']
-xsec = samples[sample]['xsec']
-c = ncores		
-ROOT.ROOT.EnableImplicitMT(c)
-print "running with {} cores".format(c)
-  
-fvec=ROOT.vector('string')()
-for dirname,fname in direc.iteritems():
-    ##check if file exists or not
-    inputFile = '/scratchssd/sroychow/NanoAOD2016-V2/{}/tree.root'.format(dirname)
-    isFile = os.path.isfile(inputFile)  
-    if not isFile:
-        print inputFile, " does not exist"
-        continue
-    fvec.push_back(inputFile)
-    print inputFile
-    #WJets = False
-    #if "WJetsToLNu" in inputFile: WJets = True
-if fvec.empty():
-    print "No files found for directory:", samples[sample], " SKIPPING processing"
-    sys.exit(1)
-print fvec 
-
-fileSF = ROOT.TFile.Open("data/ScaleFactors_OnTheFly.root")
-wdecayselections = { 
-                     'WToMu'  : ' && (abs(genVtype) == 14)',
-                     'WToTau' : ' && (abs(genVtype) == 16)'
-                    }
-p = RDFtree(outputDir = outputDir, inputFile = fvec, outputFile="{}_plots.root".format(sample), pretend=pretendJob)
-filePt = ROOT.TFile.Open("data/histoUnfoldingSystPt_nsel2_dy3_rebin1_default.root")
-fileY = ROOT.TFile.Open("data/histoUnfoldingSystRap_nsel2_dy3_rebin1_default.root")
-p.branch(nodeToStart = 'input', nodeToEnd = 'defs', modules = [ROOT.reweightFromZ(filePt,fileY),ROOT.baseDefinitions(),ROOT.weightDefinitions(fileSF),getLumiWeight(xsec=xsec, inputFile=fvec),ROOT.Replica2Hessian()])
-
-for region,cut in selections_bkg.iteritems():
-    if 'aiso' in region:
-        weight = 'float(puWeight*lumiweight*weightPt*weightY)'
-    else:
-        weight = 'float(puWeight*lumiweight*WHSF*weightPt*weightY)'
-        
-    print weight, "NOMINAL WEIGHT"
-        
-    nom = ROOT.vector('string')()
-    nom.push_back("")
-    #last argument refers to histo category - 0 = Nominal, 1 = Pt scale , 2 = MET scale
-    print "branching nominal for region:", region 
-    wtomu_cut = cut + wdecayselections['WToMu']
-    wtotau_cut = cut + wdecayselections['WToTau']
-    if region == "Signal":             
-        print "adding muon histo to graph for Signal region"
-        p.branch(nodeToStart = 'defs', nodeToEnd = '{}/prefit_{}/Nominal'.format('WToMu', region), modules = [ROOT.muonHistos(wtomu_cut, weight, nom,"Nom",0)])     
-        p.branch(nodeToStart = 'defs', nodeToEnd = '{}/prefit_{}/Nominal'.format('WToTau', region), modules = [ROOT.muonHistos(wtotau_cut, weight, nom,"Nom",0)])     
-
-    #Nominal templates
-    p.branch(nodeToStart = 'defs', nodeToEnd = '{}/templates_{}/Nominal'.format('WToMu', region), modules = [ROOT.templates(wtomu_cut, weight, nom,"Nom",0)])            
-    p.branch(nodeToStart = 'defs', nodeToEnd = '{}/templates_{}/Nominal'.format('WToTau', region), modules = [ROOT.templates(wtotau_cut, weight, nom,"Nom",0)])            
-   
-    #weight variations
-    for s,variations in systematics.iteritems():
-        print "branching weight variations", s
-        #if "LHEScaleWeight" in s and samples[sample]['systematics'] != 2 :  continue
-        if "LHEPdfWeight" in s or "LHEScaleWeight" in s :
-            var_weight = weight
-            #        if not "LHEScaleWeight" in s :
+    p = RDFtree(outputDir = outputDir, inputFile = fvec, outputFile="{}_plots.root".format(sample), pretend=pretendJob)
+    filePt = ROOT.TFile.Open("data/histoUnfoldingSystPt_nsel2_dy3_rebin1_default.root")
+    fileY = ROOT.TFile.Open("data/histoUnfoldingSystRap_nsel2_dy3_rebin1_default.root")
+    p.branch(nodeToStart = 'input', nodeToEnd = 'defs', modules = [ROOT.reweightFromZ(filePt,fileY),ROOT.baseDefinitions(),ROOT.weightDefinitions(fileSF),getLumiWeight(xsec=xsec, inputFile=fvec),ROOT.Replica2Hessian()])
+    for region,cut in selections_bkg.iteritems():
+        if 'aiso' in region:
+            weight = 'float(puWeight*lumiweight*weightPt*weightY)'
         else:
-            if 'aiso' in region: continue
-            var_weight = weight.replace(s, "1.")
-        vars_vec = ROOT.vector('string')()
-        for var in variations[0]:
-            vars_vec.push_back(var)
-        print weight,"\t",var_weight, "MODIFIED WEIGHT"
-        if region == "Signal": 
-            p.branch(nodeToStart = 'defs'.format(region), nodeToEnd = '{}/prefit_{}/{}Vars'.format('WToMu', region,s), modules = [ROOT.muonHistos(wtomu_cut, var_weight,vars_vec,variations[1], 0)])
-            p.branch(nodeToStart = 'defs'.format(region), nodeToEnd = '{}/prefit_{}/{}Vars'.format('WToTau', region,s), modules = [ROOT.muonHistos(wtotau_cut, var_weight,vars_vec,variations[1], 0)])
-        #Template vars
-        p.branch(nodeToStart = 'defs'.format(region), nodeToEnd = '{}/templates_{}/{}Vars'.format('WToMu', region,s), modules = [ROOT.templates(wtomu_cut, var_weight,vars_vec,variations[1], 0)])
-        p.branch(nodeToStart = 'defs'.format(region), nodeToEnd = '{}/templates_{}/{}Vars'.format('WToTau', region,s), modules = [ROOT.templates(wtotau_cut, var_weight,vars_vec,variations[1], 0)])
+            weight = 'float(puWeight*lumiweight*WHSF*weightPt*weightY)'
+        
+        print weight, "NOMINAL WEIGHT"
+        
+        nom = ROOT.vector('string')()
+        nom.push_back("")
+        #last argument refers to histo category - 0 = Nominal, 1 = Pt scale , 2 = MET scale
+        print "branching nominal for region:", region 
+        wtomu_cut = cut + wdecayselections['WToMu']
+        wtotau_cut = cut + wdecayselections['WToTau']
+        if region == "Signal":             
+            print "adding muon histo to graph for Signal region"
+            p.branch(nodeToStart = 'defs', nodeToEnd = '{}/prefit_{}/Nominal'.format('WToMu', region), modules = [ROOT.muonHistos(wtomu_cut, weight, nom,"Nom",0)])     
+            p.branch(nodeToStart = 'defs', nodeToEnd = '{}/prefit_{}/Nominal'.format('WToTau', region), modules = [ROOT.muonHistos(wtotau_cut, weight, nom,"Nom",0)])     
 
-    #column variations#weight will be nominal, cut will vary
-    for vartype, vardict in selectionVars.iteritems():
-        wtomu_cut_vec = ROOT.vector('string')()
-        wtomu_var_vec = ROOT.vector('string')()
-        wtotau_cut_vec = ROOT.vector('string')()
-        wtotau_var_vec = ROOT.vector('string')()
-        for selvar, hcat in vardict.iteritems() :
-            wtomu_newcut = wtomu_cut.replace('MT', 'MT'+selvar)
-            wtotau_newcut = wtotau_cut.replace('MT', 'MT'+selvar)
-            if 'corrected' in selvar:
-                wtomu_newcut = wtomu_newcut.replace('Mu1_pt', 'Mu1_pt'+selvar)
-                wtotau_newcut = wtotau_newcut.replace('Mu1_pt', 'Mu1_pt'+selvar)
-            wtomu_cut_vec.push_back(wtomu_newcut)
-            wtomu_var_vec.push_back(selvar)
-            wtotau_cut_vec.push_back(wtotau_newcut)
-            wtotau_var_vec.push_back(selvar)
-        print "branching column variations:", vartype, " for region:", region, "\tvariations:", wtomu_var_vec
-        if region == "Signal": 
-            p.branch(nodeToStart = 'defs', nodeToEnd = '{}/prefit_{}/{}Vars'.format('WToMu', region,vartype), modules = [ROOT.muonHistos(wtomu_cut_vec, weight, nom,"Nom",hcat,wtomu_var_vec)])  
-            p.branch(nodeToStart = 'defs', nodeToEnd = '{}/prefit_{}/{}Vars'.format('WToTau', region,vartype), modules = [ROOT.muonHistos(wtotau_cut_vec, weight, nom,"Nom",hcat,wtotau_var_vec)])
-        #templates 
-        p.branch(nodeToStart = 'defs', nodeToEnd = '{}/templates_{}/{}Vars'.format('WToMu', region,vartype), modules = [ROOT.templates(wtomu_cut_vec, weight, nom,"Nom",hcat,wtomu_var_vec)])  
-        p.branch(nodeToStart = 'defs', nodeToEnd = '{}/templates_{}/{}Vars'.format('WToTau', region,vartype), modules = [ROOT.templates(wtotau_cut_vec, weight, nom,"Nom",hcat,wtotau_var_vec)])  
+        #Nominal templates
+        p.branch(nodeToStart = 'defs', nodeToEnd = '{}/templates_{}/Nominal'.format('WToMu', region), modules = [ROOT.templates(wtomu_cut, weight, nom,"Nom",0)])            
+        p.branch(nodeToStart = 'defs', nodeToEnd = '{}/templates_{}/Nominal'.format('WToTau', region), modules = [ROOT.templates(wtotau_cut, weight, nom,"Nom",0)])            
+   
+        #weight variations
+        for s,variations in systematics.iteritems():
+            print "branching weight variations", s
+            #if "LHEScaleWeight" in s and samples[sample]['systematics'] != 2 :  continue
+            if "LHEPdfWeight" in s or "LHEScaleWeight" in s :
+                var_weight = weight
+                #        if not "LHEScaleWeight" in s :
+            else:
+                if 'aiso' in region: continue
+                var_weight = weight.replace(s, "1.")
+            vars_vec = ROOT.vector('string')()
+            for var in variations[0]:
+                vars_vec.push_back(var)
+            print weight,"\t",var_weight, "MODIFIED WEIGHT"
+            if region == "Signal": 
+                p.branch(nodeToStart = 'defs'.format(region), nodeToEnd = '{}/prefit_{}/{}Vars'.format('WToMu', region,s), modules = [ROOT.muonHistos(wtomu_cut, var_weight,vars_vec,variations[1], 0)])
+                p.branch(nodeToStart = 'defs'.format(region), nodeToEnd = '{}/prefit_{}/{}Vars'.format('WToTau', region,s), modules = [ROOT.muonHistos(wtotau_cut, var_weight,vars_vec,variations[1], 0)])
+            #Template vars
+            p.branch(nodeToStart = 'defs'.format(region), nodeToEnd = '{}/templates_{}/{}Vars'.format('WToMu', region,s), modules = [ROOT.templates(wtomu_cut, var_weight,vars_vec,variations[1], 0)])
+            p.branch(nodeToStart = 'defs'.format(region), nodeToEnd = '{}/templates_{}/{}Vars'.format('WToTau', region,s), modules = [ROOT.templates(wtotau_cut, var_weight,vars_vec,variations[1], 0)])
 
-p.getOutput()
-p.saveGraph()
+        #column variations#weight will be nominal, cut will vary
+        for vartype, vardict in selectionVars.iteritems():
+            wtomu_cut_vec = ROOT.vector('string')()
+            wtomu_var_vec = ROOT.vector('string')()
+            wtotau_cut_vec = ROOT.vector('string')()
+            wtotau_var_vec = ROOT.vector('string')()
+            for selvar, hcat in vardict.iteritems() :
+                wtomu_newcut = wtomu_cut.replace('MT', 'MT'+selvar)
+                wtotau_newcut = wtotau_cut.replace('MT', 'MT'+selvar)
+                if 'corrected' in selvar:
+                    wtomu_newcut = wtomu_newcut.replace('Mu1_pt', 'Mu1_pt'+selvar)
+                    wtotau_newcut = wtotau_newcut.replace('Mu1_pt', 'Mu1_pt'+selvar)
+                wtomu_cut_vec.push_back(wtomu_newcut)
+                wtomu_var_vec.push_back(selvar)
+                wtotau_cut_vec.push_back(wtotau_newcut)
+                wtotau_var_vec.push_back(selvar)
+                print "branching column variations:", vartype, " for region:", region, "\tvariations:", wtomu_var_vec
+            if region == "Signal": 
+                p.branch(nodeToStart = 'defs', nodeToEnd = '{}/prefit_{}/{}Vars'.format('WToMu', region,vartype), modules = [ROOT.muonHistos(wtomu_cut_vec, weight, nom,"Nom",hcat,wtomu_var_vec)])  
+                p.branch(nodeToStart = 'defs', nodeToEnd = '{}/prefit_{}/{}Vars'.format('WToTau', region,vartype), modules = [ROOT.muonHistos(wtotau_cut_vec, weight, nom,"Nom",hcat,wtotau_var_vec)])
+            #templates 
+            p.branch(nodeToStart = 'defs', nodeToEnd = '{}/templates_{}/{}Vars'.format('WToMu', region,vartype), modules = [ROOT.templates(wtomu_cut_vec, weight, nom,"Nom",hcat,wtomu_var_vec)])  
+            p.branch(nodeToStart = 'defs', nodeToEnd = '{}/templates_{}/{}Vars'.format('WToTau', region,vartype), modules = [ROOT.templates(wtotau_cut_vec, weight, nom,"Nom",hcat,wtotau_var_vec)])  
 
-#split the output file into decay modes
-os.chdir(outputDir)
-os.system("ls -ltrh")
-os.system("root -b -q ../python/splitWJets.C")
-os.chdir("../")
+    p.getOutput()
+    p.saveGraph()
+   
+    #if not pretendJob:
+    #split the output file into decay modes
+    os.chdir(outputDir)
+    os.system("ls -ltrh")
+    os.system("root -b -q ../python/splitWJets.C")
+    os.chdir("../")
+
+
+def main():
+    parser = argparse.ArgumentParser("")
+    parser.add_argument('-p', '--pretend',type=int, default=False, help="run over a small number of event")
+    parser.add_argument('-c', '--ncores',type=int, default=64, help="number of cores used")
+    parser.add_argument('-o', '--outputDir',type=str, default='./output/', help="output dir name")
+    parser.add_argument('-i', '--inputDir',type=str, default='/scratchssd/sroychow/NanoAOD2016-V2/', help="input dir name")
+    args = parser.parse_args()
+    pretendJob = args.pretend
+    ncores = args.ncores
+    outputDir = args.outputDir
+    inDir = args.inputDir
+    if pretendJob:
+        print "Running a test job over a few events"
+    else:
+        print "Running on full dataset"
+    samples={}
+    with open('data/samples_2016.json') as f:
+        samples = json.load(f)
+    sample='WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8'
+    print sample
+    direc = samples[sample]['dir']
+    xsec = samples[sample]['xsec']
+    fvec=ROOT.vector('string')()
+    for dirname,fname in direc.iteritems():
+        ##check if file exists or not
+        inputFile = '{}/{}/tree.root'.format(inDir, dirname)
+        isFile = os.path.isfile(inputFile)  
+        if not isFile:
+            print inputFile, " does not exist"
+            continue
+        fvec.push_back(inputFile)
+    if fvec.empty():
+        print "No files found for directory:", samples[sample], " SKIPPING processing"
+        sys.exit(1)
+    print fvec 
+
+    fileSF = ROOT.TFile.Open("data/ScaleFactors_OnTheFly.root")
+    RDFprocessWJetsMC(fvec, outputDir, sample, xsec, fileSF, ncores, pretendJob)
+
+
+if __name__ == "__main__":
+    main()

--- a/bkgAnalysis/bkg_utils.py
+++ b/bkgAnalysis/bkg_utils.py
@@ -14,7 +14,7 @@ bkg_systematics = {
     "LHEScaleWeightVars" : ["LHEScaleWeight_muR0p5_muF0p5", "LHEScaleWeight_muR0p5_muF1p0","LHEScaleWeight_muR1p0_muF0p5","LHEScaleWeight_muR1p0_muF2p0","LHEScaleWeight_muR2p0_muF1p0", "LHEScaleWeight_muR2p0_muF2p0"],
     "ptScaleVars" : [ "correctedUp", "correctedDown"], 
     "jmeVars" : [ "jerUp", "jerDown" , "jesTotalUp", "jesTotalDown", "unclustEnUp","unclustEnDown"],
-    "LHEPdfWeightVars" : ["_LHEPdfWeightHess{}".format(i+1) for i in range(60)]
+    "LHEPdfWeightVars" : ["LHEPdfWeightHess{}".format(i+1) for i in range(60)]
   }
 
 ptBinning = [25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55] 


### PR DESCRIPTION
In this PR, the configs for running over DATA and MC samples have been restructured to allow multiprocessing + multithreaded running.  Small samples are not run with MT. No change in source code.

Main features - 
- Individual configs for data, mc have been updated and they can be run individually for testing purposes. If the runAnalysisOnMC is executed from shell, all the MC samples(except WJets) will be processed in sequence.
- runAnalysis.py - this config import the other individual configs and provides the MP + MT wrapping. This should be used in production. You can pass the Ncores to run on, but for WJets and Data, the Ncores will be set according the the resource available in the machine on which it is being run. For now, on test2 this will mean 128 cores, on cmsanalysis - 64.
- runTheMatrix.py updated and timer added to the script. 
- Argparser short names fixed in all configs.
- The input dir has to be specified only while running on test2 machine[Default values is the directory on cmsanalysis]

Tests done -
on test2.pi.infn.it

python runTheMatrix.py --outputDir=outputv5 --bkgOutput=bkgv5/ --ncores=64 --bkgFile=MYBKG --bkgPrep=1 --bkgAna=1 --prefit=1 --plotter=1 --inputDir=/scratch/wmass/NanoAOD2016-V2/

on cmsanalysis
python runTheMatrix.py --outputDir=outputv5 --bkgOutput=bkgv5/ --ncores=64 --bkgFile=MYBKG --bkgPrep=1 --bkgAna=1 --prefit=1 --plotter=1

Runtime on -
test2 for step1 to 4 = 21 minutes.
cmsanalysis - 52 minutes
