### PR TITLE
sideband analysis, MCscale band, uncorrelated MC scale

### DIFF
--- a/analysisOnData/data/selections.py
+++ b/analysisOnData/data/selections.py
@@ -17,6 +17,7 @@ selections_bkg = {
 
 selections_fakes = {
   "fakes": "HLT_SingleMu24 && Mu1_pt>25.0 && Mu1_pt<55.0 && MT>=40.0 && MET_filters==1 && nVetoElectrons==0 && 1", 
+  "fakes_SideBand": "HLT_SingleMu24 && Mu1_pt>25.0 && Mu1_pt<55.0 && MT<30.0 && MET_filters==1 && nVetoElectrons==0 && 1", 
   }
 
 selectionVars = { 

--- a/analysisOnData/python/plotter_prefit.py
+++ b/analysisOnData/python/plotter_prefit.py
@@ -14,22 +14,32 @@ ROOT.gStyle.SetOptStat(0)
 
 class plotter:
     
-    def __init__(self, outDir, inDir = '', norm = 1):
+    def __init__(self, outDir, inDir = '',SBana=False):
 
         self.indir = inDir # indir containig the various outputs
         self.outdir = outDir
-        self.norm = norm
         self.PDFvar = 'LHEPdfWeightVars'
+        self.SBana = SBana
+        
+        if not self.SBana :
+            dirMC = 'prefit_Signal'
+            dirFakes = 'prefit_fakes'
+            self.SBsuff = ''
+        else :
+            dirMC = 'prefit_Sideband'
+            dirFakes = 'prefit_fakes_SideBand'
+            self.SBsuff = '_SideBand'
+            
                 
         self.sampleDict = {
-            "WToMu"      :  ['WToMu_plots.root',       'prefit_Signal',         ROOT.kRed+2,       "W^{+}#rightarrow #mu^{+}#nu_{#mu}"],         
-            "DYJets"      : ['DYJets_plots.root',      'prefit_Signal',         ROOT.kAzure+2,     "DYJets"],              
-            "WtoTau"      : ['WToTau_plots.root',      'prefit_Signal',         ROOT.kSpring+9,    "W^{#pm}#rightarrow #tau^{#pm}#nu_{#tau}"],   
-            "Top"       : ['Top_plots.root',         'prefit_Signal',         ROOT.kGreen+3,     "Top"],    
-            "DiBoson"     : ['Diboson_plots.root',     'prefit_Signal',         ROOT.kViolet+2,    "di-boson"],     
-            "SIGNAL_Fake" : ['FakeFromData_plots.root', 'prefit_fakes',          ROOT.kGray,        "QCD"],     
-            "Data"        : ['Data_plots.root',        'prefit_Signal',         1,                 "Data"]
-            }   
+            "WToMu"      :  ['WToMu_plots.root',        dirMC,         ROOT.kRed+2,       "W^{+}#rightarrow #mu^{+}#nu_{#mu}"],         
+            "DYJets"      : ['DYJets_plots.root',       dirMC,         ROOT.kAzure+2,     "DYJets"],              
+            "WtoTau"      : ['WToTau_plots.root',       dirMC,         ROOT.kSpring+9,    "W^{#pm}#rightarrow #tau^{#pm}#nu_{#tau}"],   
+            "Top"       : ['Top_plots.root',            dirMC,         ROOT.kGreen+3,     "Top"],    
+            "DiBoson"     : ['Diboson_plots.root',      dirMC,         ROOT.kViolet+2,    "di-boson"],     
+            "SIGNAL_Fake" : ['FakeFromData_plots.root', dirFakes,      ROOT.kGray,        "QCD"],     
+            "Data"        : ['Data_plots.root',         dirMC,         1,                 "Data"]
+            }    
         
         self.variableDict = {
             "Mu1_pt_plus"   :  ["Mu1_pt",   "p_{T} (#mu^{+})",    "Events /binWidth", " [GeV]"],
@@ -102,7 +112,9 @@ class plotter:
                             h2 = inFile.Get(fileInfo[1]+'/Nominal/'+varInfo[0])
                         else : 
                             h2 = inFile.Get(fileInfo[1]+'/'+sKind+'/'+varInfo[0]+'_'+sName)
+                        # print fileInfo[1]+'/'+sKind+'/'+varInfo[0]+'_'+sName
                         for s,sInfo in self.signDict.iteritems() :
+                            # print "inside=", h2
                             self.histoDict[f+s+var+sName] = h2.ProjectionX(h2.GetName() + s, sInfo[0],sInfo[0])
                             self.varBinWidth_modifier(self.histoDict[f+s+var+sName])
    
@@ -110,7 +122,7 @@ class plotter:
     def plotStack(self,skipSyst=[]):
 
         self.getHistos()
-        fname = "{dir}/stackPlots.root".format(dir=self.outdir)
+        fname = "{dir}/stackPlots{suff}.root".format(dir=self.outdir,suff=self.SBsuff)
         outFile =  ROOT.TFile(fname, "RECREATE")
         
         for var,varInfo in self.variableDict.iteritems() :
@@ -249,8 +261,8 @@ class plotter:
                 hRatioBand.GetYaxis().SetRangeUser(0.9,1.13)
             
             # can.Update()
-            can.SaveAs("{dir}/{c}.pdf".format(dir=self.outdir,c=can.GetName()))
-            can.SaveAs("{dir}/{c}.png".format(dir=self.outdir,c=can.GetName()))
+            can.SaveAs("{dir}/{c}{suff}.pdf".format(dir=self.outdir,c=can.GetName(),suff=self.SBsuff))
+            can.SaveAs("{dir}/{c}{suff}.png".format(dir=self.outdir,c=can.GetName(),suff=self.SBsuff))
 
             outFile.cd()
             can.Write()
@@ -263,7 +275,7 @@ class plotter:
         outFile.Close()
 
     def plotSyst(self,skipSyst=[]) :
-        fname = "{dir}/systPlots.root".format(dir=self.outdir)
+        fname = "{dir}/systPlots{suff}.root".format(dir=self.outdir,suff=self.SBsuff)
         outFile =  ROOT.TFile(fname, "RECREATE")
         
         for var,varInfo in self.variableDict.iteritems() :
@@ -358,8 +370,8 @@ class plotter:
                     legend.AddEntry(hdict[sName], sName.replace('LHEScaleWeight','Scale'))
             legend.Draw("SAME")
         
-            can.SaveAs("{dir}/{c}.pdf".format(dir=self.outdir,c=can.GetName()))
-            can.SaveAs("{dir}/{c}.png".format(dir=self.outdir,c=can.GetName()))
+            can.SaveAs("{dir}/{c}{suff}.pdf".format(dir=self.outdir,c=can.GetName(),suff=self.SBsuff))
+            can.SaveAs("{dir}/{c}{suff}.png".format(dir=self.outdir,c=can.GetName(),suff=self.SBsuff))
             
             outFile.cd()
             can.Write()  
@@ -459,8 +471,8 @@ class plotter:
                     
             legend2.Draw("SAME")
         
-            can2.SaveAs("{dir}/{c}.pdf".format(dir=self.outdir,c=can2.GetName()))
-            can2.SaveAs("{dir}/{c}.png".format(dir=self.outdir,c=can2.GetName()))
+            can2.SaveAs("{dir}/{c}{suff}.pdf".format(dir=self.outdir,c=can2.GetName(),suff=self.SBsuff))
+            can2.SaveAs("{dir}/{c}{suff}.png".format(dir=self.outdir,c=can2.GetName(),suff=self.SBsuff))
             
             outFile.cd()
             can2.Write()  
@@ -500,6 +512,8 @@ parser.add_argument('-o','--output', type=str, default='TEST',help="name of the 
 parser.add_argument('-i','--input', type=str, default='TEST',help="name of the input direcory with HADDED root files/if used with HADD=1, will be set to output dir")
 parser.add_argument('-s','--skipSyst', type=str, default='',nargs='*', help="list of skipped syst class as in bkgAnalysis/bkg_utils.py, separated by space")
 parser.add_argument('-c','--systComp', type=int, default=True,help="systematic uncertainity comparison plots")
+parser.add_argument('-sb', '--SBana',type=int, default=False, help="run also on the sideband (clousure test)")
+
 
 args = parser.parse_args()
 HADD = args.hadd
@@ -507,6 +521,7 @@ OUTPUT = args.output
 INPUT = args.input
 skippedSyst =args.skipSyst
 SYSTCOMP = args.systComp
+SBana = args.SBana
 
 if HADD :
     prepareHistos(inDir=INPUT,outDir=OUTPUT)
@@ -516,3 +531,9 @@ p=plotter(outDir=OUTPUT, inDir = INPUT)
 p.plotStack(skipSyst=skippedSyst)
 if SYSTCOMP :
     p.plotSyst(skipSyst=skippedSyst)
+
+if SBana :
+    pSB=plotter(outDir=OUTPUT, inDir = INPUT,SBana=SBana)
+    pSB.plotStack(skipSyst=skippedSyst)
+    if SYSTCOMP :
+        pSB.plotSyst(skipSyst=skippedSyst)

--- a/analysisOnData/runAnalysis.py
+++ b/analysisOnData/runAnalysis.py
@@ -27,6 +27,7 @@ parser.add_argument('-i', '--inputDir',type=str, default='/scratchssd/sroychow/N
 parser.add_argument('-b', '--runBKG',type=int, default=False, help="prepare the input of the bkg analysis, if =false run the prefit Plots")
 parser.add_argument('-f', '--bkgFile',type=str, default='/scratch/bertacch/wmass/wproperties-analysis/bkgAnalysis/TEST_runTheMatrix/bkg_parameters_C\
 FstatAna.root', help="bkg parameters file path/name.root")
+parser.add_argument('-sb', '--SBana',type=int, default=False, help="run also on the sideband (clousure test)")
 args = parser.parse_args()
 pretendJob = args.pretend
 ncores = args.ncores
@@ -34,6 +35,7 @@ outputDir = args.outputDir
 inDir = args.inputDir
 runBKG = args.runBKG
 bkgFile = args.bkgFile
+SBana = args.SBana
 
 #in the new machine, optimal performance with 128 cores is seen.
 ncmax = cpu_count()/2 if cpu_count() > 64 else cpu_count()
@@ -73,11 +75,11 @@ if runBKG : #produces templates for all regions and prefit for signal
       systType = samples[sample]['systematics']
 
       if 'WJets' in sample : #nc = ncpus/2
-          p = Process(target=RDFprocessWJetsMC, args=(fvec, outputDir, sample, xsec, fileSF, ncmax, pretendJob))
+          p = Process(target=RDFprocessWJetsMC, args=(fvec, outputDir, sample, xsec, fileSF, ncmax, pretendJob, runBKG,SBana))
           p.start()
           multiprocs.append(p)
       else:
-          p = Process(target=RDFprocessMC, args=(fvec, outputDir, sample, xsec, fileSF, cores, systType, pretendJob))	
+          p = Process(target=RDFprocessMC, args=(fvec, outputDir, sample, xsec, fileSF, cores, systType, pretendJob,SBana))	
           p.start()
           multiprocs.append(p)
 
@@ -101,11 +103,11 @@ if fvec.empty():
     sys.exit(1)
 print fvec
 if runBKG : #produces templates for all regions and prefit for signal
-    p = Process(target=RDFprocessData, args=(fvec, outputDir, ncmax, pretendJob))
+    p = Process(target=RDFprocessData, args=(fvec, outputDir, ncmax, pretendJob, SBana))
     p.start()
     multiprocs.append(p)
 else : #produces Fake contribution to prefit plots computed from data
-    p = Process(target=RDFprocessfakefromData, args=(fvec, outputDir, bkgFile, ncmax, pretendJob))
+    p = Process(target=RDFprocessfakefromData, args=(fvec, outputDir, bkgFile, ncmax, pretendJob, SBana))
     p.start()
     multiprocs.append(p)
 

--- a/analysisOnData/runAnalysisOnWJetsMC.py
+++ b/analysisOnData/runAnalysisOnWJetsMC.py
@@ -15,7 +15,7 @@ from getLumiWeight import getLumiWeight
 ROOT.gSystem.Load('bin/libAnalysisOnData.so')
 ROOT.gROOT.ProcessLine("gErrorIgnoreLevel = 2001;");
 
-def RDFprocessWJetsMC(fvec, outputDir, sample, xsec, fileSF, ncores, pretendJob, bkg):
+def RDFprocessWJetsMC(fvec, outputDir, sample, xsec, fileSF, ncores, pretendJob, bkg,SBana=False):
     ROOT.ROOT.EnableImplicitMT(ncores)
     print "running with {} cores for sample:{}".format(ncores, sample) 
     wdecayselections = { 
@@ -47,7 +47,7 @@ def RDFprocessWJetsMC(fvec, outputDir, sample, xsec, fileSF, ncores, pretendJob,
         #Nominal templates
         p.branch(nodeToStart = 'defs', nodeToEnd = '{}/templates_{}/Nominal'.format('WToMu', region), modules = [ROOT.templates(wtomu_cut, weight, nom,"Nom",0)])            
         p.branch(nodeToStart = 'defs', nodeToEnd = '{}/templates_{}/Nominal'.format('WToTau', region), modules = [ROOT.templates(wtotau_cut, weight, nom,"Nom",0)])
-        if region == "Signal":
+        if region == "Signal" or (region=='Sideband' and SBana):
             print "adding muon histo to graph for Signal region"
             p.branch(nodeToStart = 'defs', nodeToEnd = '{}/prefit_{}/Nominal'.format('WToMu', region), modules = [ROOT.muonHistos(wtomu_cut, weight, nom,"Nom",0)])     
             p.branch(nodeToStart = 'defs', nodeToEnd = '{}/prefit_{}/Nominal'.format('WToTau', region), modules = [ROOT.muonHistos(wtotau_cut, weight, nom,"Nom",0)])     
@@ -82,7 +82,7 @@ def RDFprocessWJetsMC(fvec, outputDir, sample, xsec, fileSF, ncores, pretendJob,
             #Template vars
             p.branch(nodeToStart = 'defs'.format(region), nodeToEnd = '{}/templates_{}/{}Vars'.format('WToMu', region,s), modules = [ROOT.templates(wtomu_cut, var_weight,vars_vec,variations[1], 0)])
             p.branch(nodeToStart = 'defs'.format(region), nodeToEnd = '{}/templates_{}/{}Vars'.format('WToTau', region,s), modules = [ROOT.templates(wtotau_cut, var_weight,vars_vec,variations[1], 0)])
-            if region == "Signal": 
+            if region == "Signal" or (region=='Sideband' and SBana):
                 p.branch(nodeToStart = 'defs'.format(region), nodeToEnd = '{}/prefit_{}/{}Vars'.format('WToMu', region,s), modules = [ROOT.muonHistos(wtomu_cut, var_weight,vars_vec,variations[1], 0)])
                 p.branch(nodeToStart = 'defs'.format(region), nodeToEnd = '{}/prefit_{}/{}Vars'.format('WToTau', region,s), modules = [ROOT.muonHistos(wtotau_cut, var_weight,vars_vec,variations[1], 0)])
                 #reco templates with AC reweighting
@@ -114,7 +114,7 @@ def RDFprocessWJetsMC(fvec, outputDir, sample, xsec, fileSF, ncores, pretendJob,
             #templates (integrated over helicity xsecs)
             p.branch(nodeToStart = 'defs', nodeToEnd = '{}/templates_{}/{}Vars'.format('WToMu', region,vartype), modules = [ROOT.templates(wtomu_cut_vec, weight, nom,"Nom",hcat,wtomu_var_vec)])  
             p.branch(nodeToStart = 'defs', nodeToEnd = '{}/templates_{}/{}Vars'.format('WToTau', region,vartype), modules = [ROOT.templates(wtotau_cut_vec, weight, nom,"Nom",hcat,wtotau_var_vec)])  
-            if region == "Signal": 
+            if region == "Signal" or (region=='Sideband' and SBana):
                 p.branch(nodeToStart = 'defs', nodeToEnd = '{}/prefit_{}/{}Vars'.format('WToMu', region,vartype), modules = [ROOT.muonHistos(wtomu_cut_vec, weight, nom,"Nom",hcat,wtomu_var_vec)])  
                 p.branch(nodeToStart = 'defs', nodeToEnd = '{}/prefit_{}/{}Vars'.format('WToTau', region,vartype), modules = [ROOT.muonHistos(wtotau_cut_vec, weight, nom,"Nom",hcat,wtotau_var_vec)])
                 #reco templates with AC reweighting
@@ -147,12 +147,14 @@ def main():
     parser.add_argument('-o', '--outputDir',type=str, default='./output/', help="output dir name")
     parser.add_argument('-i', '--inputDir',type=str, default='/scratch/wmass/NanoAOD2016-V2/', help="input dir name")
     parser.add_argument('-bkg', '--bkg',type=bool, default=False, help="get histograms for bkg analysis")
+    parser.add_argument('-sb', '--SBana',type=int, default=False, help="run also on the sideband (clousure test)")
     args = parser.parse_args()
     pretendJob = args.pretend
     ncores = args.ncores
     outputDir = args.outputDir
     inDir = args.inputDir
     bkg = args.bkg
+    SBana = args.SBana
     if pretendJob:
         print "Running a test job over a few events"
     else:
@@ -179,7 +181,7 @@ def main():
     print fvec 
 
     fileSF = ROOT.TFile.Open("data/ScaleFactors_OnTheFly.root")
-    RDFprocessWJetsMC(fvec, outputDir, sample, xsec, fileSF, ncores, pretendJob, bkg)
+    RDFprocessWJetsMC(fvec, outputDir, sample, xsec, fileSF, ncores, pretendJob, bkg,SBana)
 
 
 if __name__ == "__main__":

--- a/bkgAnalysis/bkg_config.py
+++ b/bkgAnalysis/bkg_config.py
@@ -97,8 +97,6 @@ regionList = ['']
 if SBana :
     regionList.append('SideBand')
 
-regionList = ['SideBand']
-
 for reg in regionList : 
     if mainAna :
         print "--> Not correlated analysis path:"

--- a/bkgAnalysis/bkg_config.py
+++ b/bkgAnalysis/bkg_config.py
@@ -50,6 +50,7 @@ parser.add_argument('-comparisonAna', '--compAna',type=int, default=False, help=
 parser.add_argument('-inputDir', '--inputDir',type=str, default='./data/', help="input dir name")
 parser.add_argument('-outputDir', '--outputDir',type=str, default='./bkg_V2/', help="output dir name")
 parser.add_argument('-ncores', '--ncores',type=int, default=64, help="number of cores used")
+parser.add_argument('-sideBandAna', '--SBana',type=int, default=False, help="run also on the sideband (clousure test)")
 
 args = parser.parse_args()
 mainAna = args.mainAna
@@ -59,6 +60,7 @@ systAna = args.syst
 inputDir = args.inputDir
 outputDir = args.outputDir
 ncores = args.ncores
+SBana = args.SBana
 
 
 #internal parameters:
@@ -75,78 +77,85 @@ else :
     MULTICORE=False
 
 
-def fakerate_analysis(systKind, systName,correlatedFit,statAna, template, ptBinning=bkg_utils.ptBinning, etaBinning=bkg_utils.etaBinning, outdir=outputDir, indir=inputDir, extrapSuff='') :
+def fakerate_analysis(systKind, systName,correlatedFit,statAna, template, ptBinning=bkg_utils.ptBinning, etaBinning=bkg_utils.etaBinning, outdir=outputDir, indir=inputDir, extrapSuff='',regionSuff='') :
     outdirBkg = outdir+'/bkg_'+systName+extrapSuff        
     if not os.path.isdir(outdirBkg): os.system('mkdir '+outdirBkg)
     
-    fake = bkg_fakerateAnalyzer.bkg_analyzer(systKind=systKind,systName=systName,correlatedFit=correlatedFit,statAna=statAna, ptBinning=ptBinning, etaBinning=etaBinning, outdir=outdirBkg, inputDir=indir,extrapCorr=EXTRAPCORR)
+    fake = bkg_fakerateAnalyzer.bkg_analyzer(systKind=systKind,systName=systName,correlatedFit=correlatedFit,statAna=statAna, ptBinning=ptBinning, etaBinning=etaBinning, outdir=outdirBkg, inputDir=indir,extrapCorr=EXTRAPCORR, nameSuff=regionSuff)
     fake.main_analysis(correlatedFit=correlatedFit,template=template,output4Plots=template,produce_ext_output=True,extrapSuff=extrapSuff)
     if template :
         fake.bkg_plots()
 
 def runSingleAna(par) :
-    fakerate_analysis_call = fakerate_analysis(systKind=par[0], systName=par[1], correlatedFit=par[2], statAna=par[3], template = par[4])
+    fakerate_analysis_call = fakerate_analysis(systKind=par[0], systName=par[1], correlatedFit=par[2], statAna=par[3], template = par[4], regionSuff=par[5])
 
 
 print "----> Background analyzer:"
 if not os.path.isdir(outputDir): os.system('mkdir '+outputDir)
 
-if mainAna :
-    print "--> Not correlated analysis path:"
-    fakerate_analysis(systKind=NOM[0], systName=NOM[1], correlatedFit=False, statAna=False, template = TEMPLATE)
-    if systAna :
-        processesMain = []
-        for sKind, sList in bkg_utils.bkg_systematics.iteritems():
-            for sName in sList :
-                print "-> systematic:", sKind,sName
+regionList = ['']
+if SBana :
+    regionList.append('SideBand')
+
+regionList = ['SideBand']
+
+for reg in regionList : 
+    if mainAna :
+        print "--> Not correlated analysis path:"
+        fakerate_analysis(systKind=NOM[0], systName=NOM[1], correlatedFit=False, statAna=False, template = TEMPLATE, regionSuff=reg)
+        if systAna :
+            processesMain = []
+            for sKind, sList in bkg_utils.bkg_systematics.iteritems():
+                for sName in sList :
+                    print "-> systematic:", sKind,sName
+                    if MULTICORE :
+                        processesMain.append((sKind,sName,False,False,TEMPLATE,reg))
+                    else :
+                        fakerate_analysis(systKind=sKind, systName=sName, correlatedFit=False, statAna=False, template = TEMPLATE, regionSuff=reg)
                 if MULTICORE :
-                    processesMain.append((sKind,sName,False,False,TEMPLATE))
-                else :
-                    fakerate_analysis(systKind=sKind, systName=sName, correlatedFit=False, statAna=False, template = TEMPLATE)
+                    poolMain = multiprocessing.Pool(NCORES)
+                    poolMain.map(runSingleAna,processesMain)
+
+    if correlatedFitAna :
+        print "--> Correlated analysis path:"
+        fakerate_analysis(systKind=NOM[0], systName=NOM[1], correlatedFit=True, statAna=False, template = TEMPLATE, regionSuff=reg)
+        if STATANA :
+            print "-> statistical uncertainity analysis:"
+            fakerate_analysis(systKind=NOM[0], systName=NOM[1], correlatedFit=True, statAna=STATANA, template = TEMPLATE, regionSuff=reg)
+        if systAna :
+            processesCF = []
+            for sKind, sList in bkg_utils.bkg_systematics.iteritems():
+                for sName in sList : 
+                    print "-> systematatic:", sKind,sName
+                    if MULTICORE :
+                        processesCF.append((sKind,sName,True,False,TEMPLATE,reg))
+                    else :
+                        fakerate_analysis(systKind=sKind, systName=sName, correlatedFit=True, statAna=False, template = TEMPLATE, regionSuff=reg)
             if MULTICORE :
-                poolMain = multiprocessing.Pool(NCORES)
-                poolMain.map(runSingleAna,processesMain)
+                poolCF = multiprocessing.Pool(NCORES)
+                poolCF.map(runSingleAna,processesCF)
 
-if correlatedFitAna :
-    print "--> Correlated analysis path:"
-    fakerate_analysis(systKind=NOM[0], systName=NOM[1], correlatedFit=True, statAna=False, template = TEMPLATE)
-    if STATANA :
-        print "-> statistical uncertainity analysis:"
-        fakerate_analysis(systKind=NOM[0], systName=NOM[1], correlatedFit=True, statAna=STATANA, template = TEMPLATE)
-    if systAna :
-        processesCF = []
-        for sKind, sList in bkg_utils.bkg_systematics.iteritems():
-            for sName in sList : 
-                print "-> systematatic:", sKind,sName
-                if MULTICORE :
-                    processesCF.append((sKind,sName,True,False,TEMPLATE))
-                else :
-                    fakerate_analysis(systKind=sKind, systName=sName, correlatedFit=True, statAna=False, template = TEMPLATE)
-        if MULTICORE :
-            poolCF = multiprocessing.Pool(NCORES)
-            poolCF.map(runSingleAna,processesCF)
-
-if EXTRAP :
-    print "--> Extrapolation syst evaluation:"
-    CFstring = ''
-    if CORRFITFINAL :
-        CFstring+='_CF'
-    if STATANA :
-        CFstring+='statAna'
-    if (mainAna or correlatedFitAna):
-        for lcut, lbin in bkg_utils.looseCutDict.iteritems() :    
-            print "-> Mt bin:", lbin
-            fakerate_analysis(systKind=NOM[0], systName=NOM[1], correlatedFit=False, statAna=False, template = TEMPLATE, extrapSuff=lcut)
-    fakeExtrap = bkg_fakerateAnalyzer.bkg_analyzer(systKind=NOM[0],systName=NOM[1],correlatedFit=CORRFITFINAL,statAna=False, ptBinning=bkg_utils.ptBinning, etaBinning=bkg_utils.etaBinning, outdir=outputDir, inputDir=inputDir)
-    if not os.path.isdir(outputDir+'/extrapolation_syst'): os.system('mkdir '+outputDir+'/extrapolation_syst')
-    fakeExtrap.extrapolationSyst(extrapDict=bkg_utils.looseCutDict,linearFit=True, CFstring=CFstring)
-    fakeExtrap.extrapolationSyst(extrapDict=bkg_utils.looseCutDict,linearFit=False, CFstring=CFstring)
-    if EXTRAPCORR :
-        print "extrapCorr"
-        fakerate_analysis(systKind=NOM[0], systName=NOM[1], correlatedFit=CORRFITFINAL, statAna=STATANA, template = TEMPLATE)
-                
-if comparisonAna :
-    print "--> Syst comparison plots:"
-    fakeFinal = bkg_fakerateAnalyzer.bkg_analyzer(systKind=NOM[0],systName=NOM[1],correlatedFit=CORRFITFINAL,statAna=False, ptBinning=bkg_utils.ptBinning, etaBinning=bkg_utils.etaBinning, outdir=outputDir+'/bkg_'+NOM[1], inputDir=inputDir)
-    fakeFinal.syst_comparison(systDict=bkg_utils.bkg_systematics, SymBands=True, outDir=outputDir, noratio=False, statAna=STATANA)
-    fakeFinal.buildOutput(outputDir=outputDir,statAna=STATANA)
+    if EXTRAP and reg!='SideBand' :
+        print "--> Extrapolation syst evaluation:"
+        CFstring = ''
+        if CORRFITFINAL :
+            CFstring+='_CF'
+        if STATANA :
+            CFstring+='statAna'
+        if (mainAna or correlatedFitAna):
+            for lcut, lbin in bkg_utils.looseCutDict.iteritems() :    
+                print "-> Mt bin:", lbin
+                fakerate_analysis(systKind=NOM[0], systName=NOM[1], correlatedFit=False, statAna=False, template = TEMPLATE, extrapSuff=lcut)
+        fakeExtrap = bkg_fakerateAnalyzer.bkg_analyzer(systKind=NOM[0],systName=NOM[1],correlatedFit=CORRFITFINAL,statAna=False, ptBinning=bkg_utils.ptBinning, etaBinning=bkg_utils.etaBinning, outdir=outputDir, inputDir=inputDir)
+        if not os.path.isdir(outputDir+'/extrapolation_syst'): os.system('mkdir '+outputDir+'/extrapolation_syst')
+        fakeExtrap.extrapolationSyst(extrapDict=bkg_utils.looseCutDict,linearFit=True, CFstring=CFstring)
+        fakeExtrap.extrapolationSyst(extrapDict=bkg_utils.looseCutDict,linearFit=False, CFstring=CFstring)
+        if EXTRAPCORR :
+            print "extrapCorr"
+            fakerate_analysis(systKind=NOM[0], systName=NOM[1], correlatedFit=CORRFITFINAL, statAna=STATANA, template = TEMPLATE)
+                    
+    if comparisonAna :
+        print "--> Syst comparison plots:"
+        fakeFinal = bkg_fakerateAnalyzer.bkg_analyzer(systKind=NOM[0],systName=NOM[1],correlatedFit=CORRFITFINAL,statAna=False, ptBinning=bkg_utils.ptBinning, etaBinning=bkg_utils.etaBinning, outdir=outputDir+'/bkg_'+NOM[1], inputDir=inputDir, nameSuff=reg)
+        fakeFinal.syst_comparison(systDict=bkg_utils.bkg_systematics, SymBands=True, outDir=outputDir, noratio=False, statAna=STATANA)
+        fakeFinal.buildOutput(outputDir=outputDir,statAna=STATANA)

--- a/bkgAnalysis/bkg_fakerateAnalyzer.py
+++ b/bkgAnalysis/bkg_fakerateAnalyzer.py
@@ -47,7 +47,8 @@ class bkg_analyzer:
         #     'Down' : ["LHEScaleWeight_muR0p5_muF0p5", "LHEScaleWeight_muR0p5_muF1p0", "LHEScaleWeight_muR1p0_muF0p5"],
         #     'Up' : ["LHEScaleWeight_muR2p0_muF2p0", "LHEScaleWeight_muR2p0_muF1p0","LHEScaleWeight_muR1p0_muF2p0"]   
         # }
-        
+        if self.nameSuff =='SideBand' :
+            print "WARNING: special name used, SideBand, processed sideband clousure test"
         
     def binNumb_calculator(self,histo, axis, lowEdge) : #axis can be X,Y,Z
         binout = 0
@@ -1503,9 +1504,14 @@ class bkg_analyzer:
         
         signBinning = [-2,0,2]
         if kind =='prompt' :
-            h3Num =  histo3D[kindDict[kind]+'D'].Clone(kind+'Num') #D
-            h3Den = histo3D[kindDict[kind]+'D'].Clone(kind+'Den') #D
-            h3Den.Add(histo3D[kindDict[kind]+'B']) #D+B
+            if self.nameSuff !='SideBand' :
+                h3Num =  histo3D[kindDict[kind]+'D'].Clone(kind+'Num') #D
+                h3Den = histo3D[kindDict[kind]+'D'].Clone(kind+'Den') #D
+                h3Den.Add(histo3D[kindDict[kind]+'B']) #D+B
+            else :
+                h3Num =  histo3D[kindDict[kind]+'C'].Clone(kind+'Num') #D
+                h3Den = histo3D[kindDict[kind]+'C'].Clone(kind+'Den') #D
+                h3Den.Add(histo3D[kindDict[kind]+'A']) #D+B
             
         if kind == 'fake' :
             h3Num =  histo3D[kindDict[kind]+'C'].Clone(kind+'Num') #C
@@ -1614,12 +1620,19 @@ class bkg_analyzer:
             for e in self.etaBinningS :
                 if kind =='prompt' :
                     etaBinN= self.binNumb_calculator( histo3D[kindDict[kind]+'D'],'X',self.etaBinning[self.etaBinningS.index(e)])    
-                    h1Dict[s+e] = histo3D[kindDict[kind]+'D'].ProjectionY('htempl_pt_'+kind+'_'+s+'_'+e,etaBinN,etaBinN,binS,binS,"e")
+                    if self.nameSuff !='SideBand' :    
+                        h1Dict[s+e] = histo3D[kindDict[kind]+'D'].ProjectionY('htempl_pt_'+kind+'_'+s+'_'+e,etaBinN,etaBinN,binS,binS,"e")
+                    else :
+                        h1Dict[s+e] = histo3D[kindDict[kind]+'C'].ProjectionY('htempl_pt_'+kind+'_'+s+'_'+e,etaBinN,etaBinN,binS,binS,"e")
 
                 if kind=='fake' :
                     etaBinN= self.binNumb_calculator(histo3D[kindDict[kind]+'D'],'X',self.etaBinning[self.etaBinningS.index(e)]) 
-                    hDregion = histo3D[kindDict[kind]+'D'].ProjectionY('D_pt_'+kind+'_'+s+'_'+e,etaBinN,etaBinN,binS,binS,"e")
-                    hBregion = histo3D[kindDict[kind]+'B'].ProjectionY('B_pt_'+kind+'_'+s+'_'+e,etaBinN,etaBinN,binS,binS,"e")
+                    if self.nameSuff !='SideBand' :
+                        hDregion = histo3D[kindDict[kind]+'D'].ProjectionY('D_pt_'+kind+'_'+s+'_'+e,etaBinN,etaBinN,binS,binS,"e")
+                        hBregion = histo3D[kindDict[kind]+'B'].ProjectionY('B_pt_'+kind+'_'+s+'_'+e,etaBinN,etaBinN,binS,binS,"e")
+                    else :
+                        hDregion = histo3D[kindDict[kind]+'C'].ProjectionY('D_pt_'+kind+'_'+s+'_'+e,etaBinN,etaBinN,binS,binS,"e")
+                        hBregion = histo3D[kindDict[kind]+'A'].ProjectionY('B_pt_'+kind+'_'+s+'_'+e,etaBinN,etaBinN,binS,binS,"e")
 
                     htempl_pt = ROOT.TH1F("htempl_pt_{kind}_{sign}_{eta}".format(kind=kind,sign=s,eta=e),"htempl_pt_{kind}_{sign}_{eta}".format(kind=kind,sign=s,eta=e), len(self.ptBinning)-1, array('f',self.ptBinning) )
                     htempl_fake_pt = ROOT.TH1F("htempl_fake_pt_{kind}_{sign}_{eta}".format(kind=kind,sign=s,eta=e),"htempl_fake_pt_{kind}_{sign}_{eta}".format(kind=kind,sign=s,eta=e), len(self.ptBinning)-1, array('f',self.ptBinning) )

--- a/runTheMatrix.py
+++ b/runTheMatrix.py
@@ -9,7 +9,7 @@ import time
 #
 #  usage: python runTheMatrix.py --inputDir INPUTDIR --outputDir OUTPUT --bkgOutput BKGOUT --ncores 64 --bkgFile MYBKG --bkgPrep 1 --bkgAna 1 --prefit 1 --plotter 1
 #
-#  each parameters is described below in the argparse
+#  each parameters is described below in the argparse (INPUTDIR can be omitted, OUTPUT can be the same of BKGOUT)
 #
 #  NB: if --bkgFile myBKG --> special string to use the file that runTheMatrix produce at step2. 
 #
@@ -30,7 +30,9 @@ parser.add_argument('-c', '--ncores',type=int, default=64, help="number of cores
 parser.add_argument('-q', '--bkgPrep',type=int, default=False, help="run the bkg input preparation")
 parser.add_argument('-w', '--bkgAna',type=int, default=False, help="run the bkg analysis")
 parser.add_argument('-e', '--prefit',type=int, default=False, help="run the prefit hitograms building")
-parser.add_argument('-r', '--plotter',type=int, default=False, help="run the prfit plotter, the result are saved in outputDir/plot/")
+parser.add_argument('-r', '--plotter',type=int, default=False, help="run the prefit plotter, the result are saved in outputDir/plot/")
+parser.add_argument('-sb', '--SBana',type=int, default=False, help="run also on the sideband (clousure test)")
+
 
 args = parser.parse_args()
 inputDir = args.inputDir
@@ -38,6 +40,7 @@ outputDir = args.outputDir
 bkgOutput = args.bkgOutput
 bkgFile = args.bkgFile
 ncores = str(args.ncores)
+SBana = str(args.SBana)
 step1 = args.bkgPrep
 step2 = args.bkgAna
 step3 = args.prefit
@@ -55,7 +58,7 @@ if step1 :
     print "step1: bkg input preparation... "
     os.chdir('./analysisOnData')
     if not os.path.isdir(outputDir): os.system('mkdir '+ outputDir)
-    os.system('python runAnalysis.py -p=0 -b=1 -i='+inputDir+' -c='+ncores+' -o='+outputDir)
+    os.system('python runAnalysis.py -p=0 -b=1 -i='+inputDir+' -c='+ncores+' -o='+outputDir + ' -sb='+SBana)
     os.chdir('../')
     s1end=time.time()
     runTimes.append(s1end - s1start)
@@ -68,7 +71,7 @@ if step2 :
     os.chdir('bkgAnalysis')
     #inputDir for bkgAnalysis is the outputDir of step1
     os.system('python bkg_prepareHistos.py --inputDir ../analysisOnData/'+outputDir+' --outputDir '+bkgOutput+'/bkgInput/')
-    os.system('python bkg_config.py --mainAna 1 --CFAna 1 --inputDir '+bkgOutput+'/bkgInput/hadded/ --outputDir '+bkgOutput+' --syst 1 --compAna 1 --ncores '+ncores)
+    os.system('python bkg_config.py --mainAna 1 --CFAna 1 --inputDir '+bkgOutput+'/bkgInput/hadded/ --outputDir '+bkgOutput+' --syst 1 --compAna 1 --ncores '+ncores+ ' --SBana '+SBana)
     os.chdir('../')
     s2end=time.time()
     runTimes.append(s2end - s2start)
@@ -80,7 +83,7 @@ if step3 :
     os.chdir('analysisOnData')
     if not os.path.isdir(outputDir): os.system('mkdir '+ outputDir)
     #ncores is optimized and set in the config itself, so no need to pass here
-    os.system('python runAnalysis.py -p=0 -b=0 -i='+inputDir+ ' -o=' +outputDir+ ' -f='+bkgFile)
+    os.system('python runAnalysis.py -p=0 -b=0 -i='+inputDir+ ' -o=' +outputDir+ ' -f='+bkgFile + ' -sb='+SBana)
     os.chdir('../')
     s3end=time.time()
     runTimes.append(s3end - s3start)
@@ -91,7 +94,7 @@ if step4 :
     print "step4: plotter..."
     os.chdir('analysisOnData/python')
     if not os.path.isdir('../'+outputDir): os.system('mkdir ../'+outputDir)
-    os.system('python plotter_prefit.py --hadd 1 --output ../'+outputDir+'/plot/ --input ../'+outputDir+' --systComp 1')
+    os.system('python plotter_prefit.py --hadd 1 --output ../'+outputDir+'/plot/ --input ../'+outputDir+' --systComp 1'+' -sb='+SBana)
 
     if not os.path.isdir('../'+outputDir+'/plot/hadded/template2D/'): os.system('mkdir -p ../'+outputDir+'/plot/hadded/template2D/')
     os.system('python plotter_template2D.py -o=../'+outputDir+'/plot/hadded/template2D/ -i=../'+outputDir+'/plot/hadded')
@@ -104,7 +107,7 @@ if step4 :
             if sKindInt==sKind : continue
             else : skipList+= ' '+str(sKindInt)
         print "Skipped systematics:", skipList 
-        os.system('python plotter_prefit.py --hadd 0 --output ../'+outputDir+'/plot_only_'+str(sKind)+' --input ../'+outputDir+'/plot/  --systComp 1 --skipSyst '+skipList)
+        os.system('python plotter_prefit.py --hadd 0 --output ../'+outputDir+'/plot_only_'+str(sKind)+' --input ../'+outputDir+'/plot/  --systComp 1 --skipSyst '+skipList+' -sb='+SBana)
     s4end=time.time()
     runTimes.append(s4end - s4start)
 else :   runTimes.append(0.)


### PR DESCRIPTION
**COMMIT: "sideband analysis and plot**
In this PR is implemented the bkg analysis on the sideband (mt<30 GeV). 
There is an additional parameter in runTheMatrix.py to activate it: "-sb --SBana". 

With --SB 1 runTheMatrix:
- produce _also_ prefit_Sideband hisograms in step1 (MC, WJetMC, Data)
- produce _also_  prefit_fakes_Sideband histograms in step3
- run an additional time the bkgAnalysis (on the sideband) and produce bgkParameter_Sideband file
- produce _also_ prefit plots for the sideband region

Because it increases the total running time this feature is turned OFF by default and should be used for validation purpose only.

**COMMIT: "Scale band fix (envelope)"**
MC scale variation (in bkg validation and prefit plots) shown as envelope of 6 variation instead of squared sum

**COMMIT: uncorrelated Angular coefficient MC Scale Variation**
Uncorrelated MC scale variation betweeen num and den in angular coefficients
