### PR TITLE
regulariz update. plotter update.

### DIFF
--- a/Fit/plotter_fitResult.py
+++ b/Fit/plotter_fitResult.py
@@ -102,8 +102,12 @@ class plotter :
 
         #MC (Pre Fit) angular coefficients and variations
         self.histos[suff+'MC'+'mapTot'] =  inFile.Get('angularCoefficients/mapTot')
+        self.histos[suff+'MCy'+'mapTot'] =  inFile.Get('angularCoefficients/Y')
+        self.histos[suff+'MCqt'+'mapTot'] =  inFile.Get('angularCoefficients/Pt')
         for coeff,div in self.coeffDict.iteritems() :
             self.histos[suff+'MC'+coeff] =  inFile.Get('angularCoefficients/harmonics'+coeff+'_nom_nom')
+            self.histos[suff+'MC'+'y'+coeff] =  inFile.Get('angularCoefficients/harmonicsY'+coeff+'_nom_nom')
+            self.histos[suff+'MC'+'qt'+coeff] =  inFile.Get('angularCoefficients/harmonicsPt'+coeff+'_nom_nom')
 
         for sKind, sList in self.systDict.iteritems():
 
@@ -113,6 +117,8 @@ class plotter :
             
             for sName in sListMod :
                 self.histos[suff+'MC'+sName+'mapTot'] =  inFile.Get('angularCoefficients'+sKind+'/mapTot'+sName)
+                self.histos[suff+'MCy'+sName+'mapTot'] =  inFile.Get('angularCoefficients'+sKind+'/Y'+sName)
+                self.histos[suff+'MCqt'+sName+'mapTot'] =  inFile.Get('angularCoefficients'+sKind+'/Pt'+sName)
                 for sNameDen in sListMod :
                     if sNameDen!=sName and not (sKind=='_LHEScaleWeight' and UNCORR) : #PDF or correlated Scale
                         continue 
@@ -123,10 +129,16 @@ class plotter :
                         if UNCORR :
                             if sKind=='_LHEScaleWeight':
                                 self.histos[suff+'MC'+sName+sNameDen+coeff] =  inFile.Get('angularCoefficients'+sKind+'/harmonics'+coeff+sName+sNameDen)
+                                self.histos[suff+'MCy'+sName+sNameDen+coeff] =  inFile.Get('angularCoefficients'+sKind+'/harmonicsY'+coeff+sName+sNameDen)
+                                self.histos[suff+'MCqt'+sName+sNameDen+coeff] =  inFile.Get('angularCoefficients'+sKind+'/harmonicsPt'+coeff+sName+sNameDen)
                             else :
                                 self.histos[suff+'MC'+sName+coeff] =  inFile.Get('angularCoefficients'+sKind+'/harmonics'+coeff+sName+sNameDen)
+                                self.histos[suff+'MCy'+sName+coeff] =  inFile.Get('angularCoefficients'+sKind+'/harmonicsY'+coeff+sName+sNameDen)
+                                self.histos[suff+'MCqt'+sName+coeff] =  inFile.Get('angularCoefficients'+sKind+'/harmonicsPt'+coeff+sName+sNameDen)
                         else :
                             self.histos[suff+'MC'+sName+coeff] =  inFile.Get('angularCoefficients'+sKind+'/harmonics'+coeff+sName) 
+                            self.histos[suff+'MCy'+sName+coeff] =  inFile.Get('angularCoefficients'+sKind+'/harmonicsY'+coeff+sName) 
+                            self.histos[suff+'MCqt'+sName+coeff] =  inFile.Get('angularCoefficients'+sKind+'/harmonicsPt'+coeff+sName) 
         
          
         #fit - helicity xsecs histos 
@@ -175,9 +187,11 @@ class plotter :
                             pass
                 for j in range(1, self.histos[suff+'FitAC'+c].GetNbinsY()+1): #loop over pt bins
                     try:
-                        coeff = eval('ev.pt_{j}_helmeta_{c}'.format(c=c, j=j))
-                        coeff_err = eval('ev.pt_{j}_helmeta_{c}_err'.format(c=c, j=j))
-                        
+                        coeff = eval('ev.qt_{j}_helmeta_{c}'.format(c=c, j=j))
+                        coeff_err = eval('ev.qt_{j}_helmeta_{c}_err'.format(c=c, j=j))
+                        if 'unpol' in c:
+                                coeff = coeff/(3./16./math.pi)
+                                coeff_err = coeff_err/(3./16./math.pi)
                         self.histos[suff+'FitACqt'+c].SetBinContent(j,coeff)
                         self.histos[suff+'FitACqt'+c].SetBinError(j,coeff_err)
 
@@ -188,7 +202,9 @@ class plotter :
                     try:
                         coeff = eval('ev.y_{i}_helmeta_{c}'.format(c=c, i=i))
                         coeff_err = eval('ev.y_{i}_helmeta_{c}_err'.format(c=c, i=i))
-                        
+                        if 'unpol' in c:
+                                coeff = coeff/(3./16./math.pi)
+                                coeff_err = coeff_err/(3./16./math.pi)
                         self.histos[suff+'FitACy'+c].SetBinContent(i,coeff)
                         self.histos[suff+'FitACy'+c].SetBinError(i,coeff_err)
 
@@ -205,41 +221,95 @@ class plotter :
         FitFile = ROOT.TFile.Open(fitFile)
         inFile = ROOT.TFile.Open(inputFile)
         self.getHistos(inFile=inFile, FitFile=FitFile, uncorrelate=uncorrelate,suff=suff)
-        print "WARNING: syst.band done with the fit central value (ok if asimov only)"
+        # print "WARNING: syst.band done with the fit central value (ok if asimov only)"
         
         # ------------- build the bands for the angular coefficient ---------------------------# 
         for c in self.coeffDict:
-            self.histos[suff+'FitBand'+c] = self.histos[suff+'FitAC'+c].Clone('FitBand'+c) #from fit (good in case of asimov)
-            self.histos[suff+'FitBandPDF'+c] = self.histos[suff+'FitAC'+c].Clone('FitBandPDF'+c) #from fit (good in case of asimov) NB: NB: not used in the plots now
-            self.histos[suff+'FitBandScale'+c] = self.histos[suff+'FitAC'+c].Clone('FitBandScale'+c) #from fit (good in case of asimov) NB: not used in the plots now
-
+            # self.histos[suff+'FitBand'+c] = self.histos[suff+'FitAC'+c].Clone('FitBand'+c) #from fit (good in case of asimov)
+            # self.histos[suff+'FitBandPDF'+c] = self.histos[suff+'FitAC'+c].Clone('FitBandPDF'+c) #from fit (good in case of asimov) NB: NB: not used in the plots now
+            # self.histos[suff+'FitBandScale'+c] = self.histos[suff+'FitAC'+c].Clone('FitBandScale'+c) #from fit (good in case of asimov) NB: not used in the plots now
             
-            #UNCOMMENT THIS BLOCK IF NOT ASIMOV FIT (and don't plot for reco) NOT FULLY IMPLMENTED!!!
-            # if not "unpol" in c: 
-                # self.histos[suff+'FitBand'+c] = self.histos[suff+'MC'+c].Clone('FitBand'+c)
-            # else:
-                # self.histos[suff+'FitBand'+c] = self.histos[suff+'MC'+'mapTot'].Clone('FitBand'+c)
-                #self.histos[suff+'FitBand'+c].Scale(1./35.9)
+            # self.histos[suff+'FitBandy'+c] = self.histos[suff+'FitACy'+c].Clone('FitBandy'+c)
+            # self.histos[suff+'FitBandPDFy'+c] = self.histos[suff+'FitACy'+c].Clone('FitBandPDFy'+c)
+            # self.histos[suff+'FitBandScaley'+c] = self.histos[suff+'FitACy'+c].Clone('FitBandScaley'+c)
+            
+            # self.histos[suff+'FitBandqt'+c] = self.histos[suff+'FitACqt'+c].Clone('FitBandqt'+c)
+            # self.histos[suff+'FitBandPDFqt'+c] = self.histos[suff+'FitACqt'+c].Clone('FitBandPDFqt'+c)
+            # self.histos[suff+'FitBandScaleqt'+c] = self.histos[suff+'FitACqt'+c].Clone('FitBandScaleqt'+c)
+            if not "unpol" in c:    
+                self.histos[suff+'FitBand'+c] = self.histos[suff+'MC'+c].Clone('FitBand'+c)
+                self.histos[suff+'FitBandPDF'+c] = self.histos[suff+'MC'+c].Clone('FitBandPDF'+c) 
+                self.histos[suff+'FitBandScale'+c] = self.histos[suff+'MC'+c].Clone('FitBandScale'+c) 
+                
+                self.histos[suff+'FitBandy'+c] = self.histos[suff+'MC'+'y'+c].Clone('FitBandy'+c)
+                self.histos[suff+'FitBandPDFy'+c] = self.histos[suff+'MC'+'y'+c].Clone('FitBandPDFy'+c)
+                self.histos[suff+'FitBandScaley'+c] = self.histos[suff+'MC'+'y'+c].Clone('FitBandScaley'+c)
+                
+                self.histos[suff+'FitBandqt'+c] = self.histos[suff+'MC'+'qt'+c].Clone('FitBandqt'+c)
+                self.histos[suff+'FitBandPDFqt'+c] = self.histos[suff+'MC'+'qt'+c].Clone('FitBandPDFqt'+c)
+                self.histos[suff+'FitBandScaleqt'+c] = self.histos[suff+'MC'+'qt'+c].Clone('FitBandScaleqt'+c)
+            else :
+                self.histos[suff+'FitBand'+c] = self.histos[suff+'MC'+'mapTot'].Clone('FitBand'+c)
+                self.histos[suff+'FitBandPDF'+c] = self.histos[suff+'MC'+'mapTot'].Clone('FitBandPDF'+c) 
+                self.histos[suff+'FitBandScale'+c] = self.histos[suff+'MC'+'mapTot'].Clone('FitBandScale'+c) 
+                
+                self.histos[suff+'FitBandy'+c] = self.histos[suff+'MC'+'y'+'mapTot'].Clone('FitBandy'+c)
+                self.histos[suff+'FitBandPDFy'+c] = self.histos[suff+'MC'+'y'+'mapTot'].Clone('FitBandPDFy'+c)
+                self.histos[suff+'FitBandScaley'+c] = self.histos[suff+'MC'+'y'+'mapTot'].Clone('FitBandScaley'+c)
+                
+                self.histos[suff+'FitBandqt'+c] = self.histos[suff+'MC'+'qt'+'mapTot'].Clone('FitBandqt'+c)
+                self.histos[suff+'FitBandPDFqt'+c] = self.histos[suff+'MC'+'qt'+'mapTot'].Clone('FitBandPDFqt'+c)
+                self.histos[suff+'FitBandScaleqt'+c] = self.histos[suff+'MC'+'qt'+'mapTot'].Clone('FitBandScaleqt'+c)
+                self.histos[suff+'FitBand'+c].Scale(1/35.9)
+                self.histos[suff+'FitBandPDF'+c].Scale(1/35.9)
+                self.histos[suff+'FitBandScale'+c].Scale(1/35.9)
+                self.histos[suff+'FitBandy'+c].Scale(1/35.9)
+                self.histos[suff+'FitBandPDFy'+c].Scale(1/35.9)
+                self.histos[suff+'FitBandScaley'+c].Scale(1/35.9)
+                self.histos[suff+'FitBandqt'+c].Scale(1/35.9)
+                self.histos[suff+'FitBandPDFqt'+c].Scale(1/35.9)
+                self.histos[suff+'FitBandScaleqt'+c].Scale(1/35.9)
+
 
             for i in range(1, self.histos[suff+'FitAC'+c].GetNbinsX()+1): #loop over rapidity bins
                 for j in range(1, self.histos[suff+'FitAC'+c].GetNbinsY()+1): #loop over pt bins
+                
+                    #debug unclousure
+                    if self.histos[suff+'FitBand'+c].GetBinContent(i,j)!=  self.histos[suff+'FitAC'+c].GetBinContent(i,j) :
+                            print "not clousure of", c, i, j , ",   (fitted-mc)/fitted=", (self.histos[suff+'FitBand'+c].GetBinContent(i,j)-self.histos[suff+'FitAC'+c].GetBinContent(i,j))/self.histos[suff+'FitAC'+c].GetBinContent(i,j)
+                
+                
                     errPDF = 0.
-                    MCVal = self.histos[suff+'FitAC'+c].GetBinContent(i,j) #form Fit (the same in case of asimov fit)
+                    if i==1 : errPDFqt = 0.
+                    if j==1 : errPDFy = 0.
+                    MCVal = self.histos[suff+'FitBand'+c].GetBinContent(i,j) #like MC, but already lumi scaled
                     # if 'unpol' in c:
                     #     MCVal=MCVal/35.9
+                    if i==1 : MCValqt = self.histos[suff+'FitBandqt'+c].GetBinContent(j)
+                    if j==1 : MCValy = self.histos[suff+'FitBandy'+c].GetBinContent(i)
                     
                     for sName in self.systDict['_LHEPdfWeight']:
                         if 'unpol' in c:
                             systVal=self.histos[suff+'MC'+sName+'mapTot'].GetBinContent(i,j)/35.9
+                            if i==1 : systValqt=self.histos[suff+'MCqt'+sName+'mapTot'].GetBinContent(j)/35.9
+                            if j==1 : systValy=self.histos[suff+'MCy'+sName+'mapTot'].GetBinContent(i)/35.9
                         else:
                             systVal = self.histos[suff+'MC'+sName+c].GetBinContent(i,j)
+                            if i==1 : systValqt = self.histos[suff+'MCqt'+sName+c].GetBinContent(j)
+                            if j==1 : systValy = self.histos[suff+'MCy'+sName+c].GetBinContent(i)
                         errPDF+= (MCVal - systVal)**2  
+                        if i==1 : errPDFqt+= (MCValqt - systValqt)**2  
+                        if j==1 : errPDFy+= (MCValy - systValy)**2  
                     self.histos[suff+'FitBandPDF'+c].SetBinError(i,j,math.sqrt(errPDF)) 
+                    if i==1 : self.histos[suff+'FitBandPDFqt'+c].SetBinError(j,math.sqrt(errPDFqt)) 
+                    if j==1 : self.histos[suff+'FitBandPDFy'+c].SetBinError(i,math.sqrt(errPDFy)) 
                             
                     sListMod = copy.deepcopy(self.systDict['_LHEScaleWeight'])
                     if UNCORR :
                         sListMod.append("_nom") #add nominal variation
                     errScale = 0.
+                    if i==1 : errScaleqt = 0.
+                    if j==1 : errScaley = 0.
                     for sName in sListMod:
                         for sNameDen in sListMod :
                             if sNameDen!=sName and not UNCORR : continue
@@ -248,24 +318,42 @@ class plotter :
                             if ([sName,sNameDen] in self.vetoScaleList) : continue  #extremal cases
                             if 'unpol' in c:
                                 systVal=self.histos[suff+'MC'+sName+'mapTot'].GetBinContent(i,j)/35.9
+                                if i==1 : systValqt =self.histos[suff+'MCqt'+sName+'mapTot'].GetBinContent(j)/35.9
+                                if j==1 : systValy =self.histos[suff+'MCy'+sName+'mapTot'].GetBinContent(i)/35.9
                             else:
                                 if UNCORR :
                                     systVal = self.histos[suff+'MC'+sName+sNameDen+c].GetBinContent(i,j)
+                                    if i==1 : systValqt = self.histos[suff+'MCqt'+sName+sNameDen+c].GetBinContent(j)
+                                    if j==1 : systValy = self.histos[suff+'MCy'+sName+sNameDen+c].GetBinContent(i)
                                 else : 
                                     systVal = self.histos[suff+'MC'+sName+c].GetBinContent(i,j)
+                                    if i==1 : systValqt = self.histos[suff+'MCqt'+sName+c].GetBinContent(j)
+                                    if j==1 : systValy = self.histos[suff+'MCy'+sName+c].GetBinContent(i)
                             err_temp= (MCVal - systVal)**2
+                            if i==1 : err_tempqt= (MCValqt - systValqt)**2
+                            if j==1 : err_tempy= (MCValy - systValy)**2
                             if err_temp>errScale : 
                                 errScale = err_temp
+                            if i==1 and err_tempqt>errScaleqt : errScaleqt = err_tempqt
+                            if j==1 and err_tempy>errScaley : errScaley = err_tempy
+                                
                     self.histos[suff+'FitBandScale'+c].SetBinError(i,j,math.sqrt(errScale)) 
+                    if i==1 : self.histos[suff+'FitBandScaleqt'+c].SetBinError(j,math.sqrt(errScaleqt)) 
+                    if j==1 : self.histos[suff+'FitBandScaley'+c].SetBinError(i,math.sqrt(errScaley)) 
 
                     err=errPDF+errScale
+                    if i==1 : errqt=errPDFqt+errScaleqt
+                    if j==1 : erry=errPDFy+errScaley
+                    
                     self.histos[suff+'FitBand'+c].SetBinError(i,j,math.sqrt(err)) 
+                    if i==1 : self.histos[suff+'FitBandqt'+c].SetBinError(j,math.sqrt(errqt)) 
+                    if j==1 : self.histos[suff+'FitBandy'+c].SetBinError(i,math.sqrt(erry)) 
         
         #--------------- build the relative uncertainity breakdown plots -----------------------#
         for c in self.coeffDict:
-            self.histos[suff+'FitErr'+c] = self.histos[suff+'FitAC'+c].Clone('FitErr'+c) #from fit (good in case of asimov)
-            self.histos[suff+'FitErrPDF'+c] = self.histos[suff+'FitBandPDF'+c].Clone('FitErrPDF'+c) #from fit (good in case of asimov)
-            self.histos[suff+'FitErrScale'+c] = self.histos[suff+'FitBandScale'+c].Clone('FitErrScale'+c) #from fit (good in case of asimov)
+            self.histos[suff+'FitErr'+c] = self.histos[suff+'FitAC'+c].Clone('FitErr'+c) 
+            self.histos[suff+'FitErrPDF'+c] = self.histos[suff+'FitBandPDF'+c].Clone('FitErrPDF'+c) 
+            self.histos[suff+'FitErrScale'+c] = self.histos[suff+'FitBandScale'+c].Clone('FitErrScale'+c) 
             for i in range(1, self.histos[suff+'FitAC'+c].GetNbinsX()+1): 
                 for j in range(1, self.histos[suff+'FitAC'+c].GetNbinsY()+1):
                     valCentral = self.histos[suff+'FitAC'+c].GetBinContent(i,j)
@@ -276,7 +364,35 @@ class plotter :
                     self.histos[suff+'FitErrPDF'+c].SetBinError(i,j,0)
                     self.histos[suff+'FitErrScale'+c].SetBinError(i,j,0)   
                     # print suff, c, i, j, "central=",valCentral, "main=", self.histos[suff+'FitErr'+c].GetBinContent(i,j), "pdf=",self.histos[suff+'FitErrPDF'+c].GetBinContent(i,j),"scale=",self.histos[suff+'FitErrScale'+c].GetBinContent(i,j)
-          
+        
+        #--------------- build the relative uncertainity breakdown plots - Y TREND -----------------------#
+        for c in self.coeffDict:
+            self.histos[suff+'FitErry'+c] = self.histos[suff+'FitACy'+c].Clone('FitErry'+c) 
+            self.histos[suff+'FitErrPDFy'+c] = self.histos[suff+'FitBandPDFy'+c].Clone('FitErrPDFy'+c) 
+            self.histos[suff+'FitErrScaley'+c] = self.histos[suff+'FitBandScaley'+c].Clone('FitErrScaley'+c) 
+            for i in range(1, self.histos[suff+'FitACy'+c].GetNbinsX()+1): 
+                valCentral = self.histos[suff+'FitACy'+c].GetBinContent(i)
+                self.histos[suff+'FitErry'+c].SetBinContent(i, self.histos[suff+'FitErry'+c].GetBinError(i)/abs(valCentral))
+                self.histos[suff+'FitErrPDFy'+c].SetBinContent(i,self.histos[suff+'FitErrPDFy'+c].GetBinError(i)/abs(valCentral))
+                self.histos[suff+'FitErrScaley'+c].SetBinContent(i,self.histos[suff+'FitErrScaley'+c].GetBinError(i)/abs(valCentral))
+                self.histos[suff+'FitErry'+c].SetBinError(i,0)
+                self.histos[suff+'FitErrPDFy'+c].SetBinError(i,0)
+                self.histos[suff+'FitErrScaley'+c].SetBinError(i,0)     
+        
+        #--------------- build the relative uncertainity breakdown plots - qt TREND -----------------------#
+        for c in self.coeffDict:
+            self.histos[suff+'FitErrqt'+c] = self.histos[suff+'FitACqt'+c].Clone('FitErrqt'+c) 
+            self.histos[suff+'FitErrPDFqt'+c] = self.histos[suff+'FitBandPDFqt'+c].Clone('FitErrPDFqt'+c) 
+            self.histos[suff+'FitErrScaleqt'+c] = self.histos[suff+'FitBandScaleqt'+c].Clone('FitErrScaleqt'+c) 
+            for i in range(1, self.histos[suff+'FitAC'+c].GetNbinsY()+1):
+                valCentral = self.histos[suff+'FitACqt'+c].GetBinContent(i)
+                self.histos[suff+'FitErrqt'+c].SetBinContent(i, self.histos[suff+'FitErrqt'+c].GetBinError(i)/abs(valCentral))
+                self.histos[suff+'FitErrPDFqt'+c].SetBinContent(i,self.histos[suff+'FitErrPDFqt'+c].GetBinError(i)/abs(valCentral))
+                self.histos[suff+'FitErrScaleqt'+c].SetBinContent(i,self.histos[suff+'FitErrScaleqt'+c].GetBinError(i)/abs(valCentral))
+                self.histos[suff+'FitErrqt'+c].SetBinError(i,0)
+                self.histos[suff+'FitErrPDFqt'+c].SetBinError(i,0)
+                self.histos[suff+'FitErrScaleqt'+c].SetBinError(i,0)    
+                    
         #---------------------- build the covariance and correlation matrices --------- #
         for c in self.coeffDict:# y large, qt fine        
             self.histos[suff+'corrMat'+c] = ROOT.TH2D(suff+'corrMat_{c}'.format(c=c), suff+'corrMat_{c}'.format(c=c), len(self.unrolledYQt)-1, array('f',self.unrolledYQt), len(self.unrolledYQt)-1, array('f',self.unrolledYQt))
@@ -337,7 +453,7 @@ class plotter :
                 self.canvas[suff+'FitAC'+'qt'+str(i)+c].SetGridy()
                 self.histos[suff+'FitAC'+'qt'+str(i)+c] = self.histos[suff+'FitAC'+c].ProjectionY("projQt{}_{}".format(i,c),i,i)
                 self.histos[suff+'FitBand'+'qt'+str(i)+c] = self.histos[suff+'FitBand'+c].ProjectionY("projQt{}_{}_err".format(i,c),i,i)
-                self.histos[suff+'FitAC'+'qt'+str(i)+c].SetTitle(c+" vs W transverse momentum, "+str(self.yArr[i-1])+"<Y_{W}<"+str(self.yArr[i]))
+                self.histos[suff+'FitAC'+'qt'+str(i)+c].SetTitle(suff+' '+c+" vs W transverse momentum, "+str(self.yArr[i-1])+"<Y_{W}<"+str(self.yArr[i]))
                 self.canvas[suff+'FitAC'+'qt'+str(i)+c].cd()
                 self.histos[suff+'FitAC'+'qt'+str(i)+c].GetXaxis().SetTitle('q_{T}^{W} [GeV]')
                 self.histos[suff+'FitAC'+'qt'+str(i)+c].GetYaxis().SetTitle(c)
@@ -360,7 +476,7 @@ class plotter :
                 self.canvas[suff+'FitAC'+'y'+str(j)+c].SetGridy()
                 self.histos[suff+'FitAC'+'y'+str(j)+c] = self.histos[suff+'FitAC'+c].ProjectionX("projY{}_{}".format(j,c),j,j)
                 self.histos[suff+'FitBand'+'y'+str(j)+c] = self.histos[suff+'FitBand'+c].ProjectionX("projY{}_{}_err".format(j,c),j,j)
-                self.histos[suff+'FitAC'+'y'+str(j)+c].SetTitle(c+" vs W rapidity, "+str(self.qtArr[j-1])+"<q_{T}^{W}<"+str(self.qtArr[j]))
+                self.histos[suff+'FitAC'+'y'+str(j)+c].SetTitle(suff+' '+c+" vs W rapidity, "+str(self.qtArr[j-1])+"<q_{T}^{W}<"+str(self.qtArr[j]))
                 self.canvas[suff+'FitAC'+'y'+str(j)+c].cd()
                 self.histos[suff+'FitAC'+'y'+str(j)+c].GetXaxis().SetTitle('Y_{W}')
                 self.histos[suff+'FitAC'+'y'+str(j)+c].GetYaxis().SetTitle(c)
@@ -463,6 +579,49 @@ class plotter :
             self.histos[suff+'FitAC'+'UNRyqt'+c].DrawCopy("same") #to have foreground
             
             
+            #--------------------- Ai QT only canvas -------------------------#                
+            self.canvas[suff+'FitAC'+'qt'+c] = ROOT.TCanvas(suff+"_c_QT_{}".format(c),suff+"_c_QT_{}".format(c))
+            self.canvas[suff+'FitAC'+'qt'+c].SetGridx()
+            self.canvas[suff+'FitAC'+'qt'+c].SetGridy()
+            self.histos[suff+'FitAC'+'qt'+c].SetTitle(suff+' '+c+" vs W transverse momentum, Y integrated")
+            self.canvas[suff+'FitAC'+'qt'+c].cd()
+            self.histos[suff+'FitAC'+'qt'+c].GetXaxis().SetTitle('q_{T}^{W} [GeV]')
+            self.histos[suff+'FitAC'+'qt'+c].GetYaxis().SetTitle(c)
+            self.histos[suff+'FitAC'+'qt'+c].SetLineWidth(2)
+            self.histos[suff+'FitAC'+'qt'+c].SetStats(0)
+            self.histos[suff+'FitAC'+'qt'+c].Draw()
+            if not 'unpol' in c :
+                self.histos[suff+'FitAC'+'qt'+c].GetYaxis().SetRangeUser(-4,4)
+            self.histos[suff+'FitBand'+'qt'+c].SetFillColor(ROOT.kOrange-3)
+            self.histos[suff+'FitBand'+'qt'+c].SetFillStyle(0)
+            self.histos[suff+'FitBand'+'qt'+c].SetLineColor(ROOT.kOrange-3)
+            self.histos[suff+'FitBand'+'qt'+c].SetLineWidth(2)
+            self.histos[suff+'FitBand'+'qt'+c].DrawCopy("E2 same")
+            self.histos[suff+'FitBand'+'qt'+c].SetFillStyle(3001)
+            self.histos[suff+'FitBand'+'qt'+c].Draw("E2 same")
+            self.histos[suff+'FitAC'+'qt'+c].DrawCopy("same") #to have foreground
+            
+            #--------------------- Ai Y only canvas -------------------------#          
+            self.canvas[suff+'FitAC'+'y'+c] = ROOT.TCanvas(suff+"_c_Y_{}".format(c),suff+"_c_Y_{}".format(c))
+            self.canvas[suff+'FitAC'+'y'+c].SetGridx()
+            self.canvas[suff+'FitAC'+'y'+c].SetGridy()
+            self.histos[suff+'FitAC'+'y'+c].SetTitle(suff+' '+c+" vs W rapidity,  q_{T} integrated")
+            self.canvas[suff+'FitAC'+'y'+c].cd()
+            self.histos[suff+'FitAC'+'y'+c].GetXaxis().SetTitle('Y_{W}')
+            self.histos[suff+'FitAC'+'y'+c].GetYaxis().SetTitle(c)
+            self.histos[suff+'FitAC'+'y'+c].SetLineWidth(2)
+            self.histos[suff+'FitAC'+'y'+c].SetStats(0)
+            self.histos[suff+'FitAC'+'y'+c].Draw()
+            if not 'unpol' in c :
+                self.histos[suff+'FitAC'+'y'+c].GetYaxis().SetRangeUser(-4,4)
+            self.histos[suff+'FitBand'+'y'+c].SetFillColor(ROOT.kMagenta-7)
+            self.histos[suff+'FitBand'+'y'+c].SetFillStyle(0)
+            self.histos[suff+'FitBand'+'y'+c].SetLineColor(ROOT.kMagenta-7)
+            self.histos[suff+'FitBand'+'y'+c].SetLineWidth(2)
+            self.histos[suff+'FitBand'+'y'+c].DrawCopy("E2 same")
+            self.histos[suff+'FitBand'+'y'+c].SetFillStyle(3001)
+            self.histos[suff+'FitBand'+'y'+c].Draw("E2 same")
+            self.histos[suff+'FitAC'+'y'+c].DrawCopy("same") #to have foreground
         
         
              #--------------- Ai 1D relative syst. band canvas -------------------#
@@ -605,6 +764,58 @@ class plotter :
             self.leg[suff+'FitErr'+'UNRyqt'+c].AddEntry(self.histos[suff+'FitErrScale'+'UNRyqt'+c],self.groupedSystColors['LHEScaleWeightVars'][1])
             self.leg[suff+'FitErr'+'UNRyqt'+c].Draw("Same")
             
+            
+            #--------------- Ai QT only relative syst. band canvas -------------------#
+            self.canvas[suff+'FitErr'+'qt'+c] = ROOT.TCanvas(suff+"_c_QT_{}_Err".format(c),suff+"_c_QT_{}_Err".format(c))
+            self.canvas[suff+'FitErr'+'qt'+c].SetGridx()
+            self.canvas[suff+'FitErr'+'qt'+c].SetGridy()
+            self.leg[suff+'FitErr'+'qt'+c] = ROOT.TLegend(0.6,0.75,0.9,0.9)
+            self.histos[suff+'FitErr'+'qt'+c].SetTitle(suff+' '+c+" relative uncertainity vs W transverse momentum, Y integrated")
+            self.canvas[suff+'FitErr'+'qt'+c].cd()
+            self.histos[suff+'FitErr'+'qt'+c].GetXaxis().SetTitle('q_{T}^{W} [GeV]')
+            self.histos[suff+'FitErr'+'qt'+c].GetYaxis().SetTitle('#Delta'+c+'/'+c)
+            self.histos[suff+'FitErr'+'qt'+c].GetYaxis().SetRangeUser(0.001,7000)
+            self.canvas[suff+'FitErr'+'qt'+c].SetLogy()
+            self.histos[suff+'FitErr'+'qt'+c].SetLineWidth(3)
+            self.histos[suff+'FitErr'+'qt'+c].SetStats(0)
+            self.histos[suff+'FitErr'+'qt'+c].Draw('hist')
+            self.histos[suff+'FitErr'+'qt'+c].SetLineColor(self.groupedSystColors['Nominal'][0])
+            self.histos[suff+'FitErrPDF'+'qt'+c].SetLineColor(self.groupedSystColors['LHEPdfWeightVars'][0])
+            self.histos[suff+'FitErrScale'+'qt'+c].SetLineColor(self.groupedSystColors['LHEScaleWeightVars'][0])
+            self.histos[suff+'FitErrPDF'+'qt'+c].SetLineWidth(3)
+            self.histos[suff+'FitErrScale'+'qt'+c].SetLineWidth(3)
+            self.histos[suff+'FitErrPDF'+'qt'+c].Draw("hist same")
+            self.histos[suff+'FitErrScale'+'qt'+c].Draw("hist same")
+            self.leg[suff+'FitErr'+'qt'+c].AddEntry(self.histos[suff+'FitErr'+'qt'+c],self.groupedSystColors['Nominal'][1])
+            self.leg[suff+'FitErr'+'qt'+c].AddEntry(self.histos[suff+'FitErrPDF'+'qt'+c],self.groupedSystColors['LHEPdfWeightVars'][1])
+            self.leg[suff+'FitErr'+'qt'+c].AddEntry(self.histos[suff+'FitErrScale'+'qt'+c],self.groupedSystColors['LHEScaleWeightVars'][1])
+            self.leg[suff+'FitErr'+'qt'+c].Draw("Same")
+            
+            #--------------- Ai Y only relative syst. band canvas -------------------#
+            self.canvas[suff+'FitErr'+'y'+c] = ROOT.TCanvas(suff+"_c_Y_{}_Err".format(c),suff+"_c_Y_{}_Err".format(c))
+            self.canvas[suff+'FitErr'+'y'+c].SetGridx()
+            self.canvas[suff+'FitErr'+'y'+c].SetGridy()
+            self.leg[suff+'FitErr'+'y'+c] = ROOT.TLegend(0.6,0.75,0.9,0.9)
+            self.histos[suff+'FitErr'+'y'+c].SetTitle(suff+' '+c+"relative uncertainity vs W rapidity,  q_{T} integrated")
+            self.canvas[suff+'FitErr'+'y'+c].cd()
+            self.histos[suff+'FitErr'+'y'+c].GetXaxis().SetTitle('Y_{W}')
+            self.histos[suff+'FitErr'+'y'+c].GetYaxis().SetTitle('#Delta'+c+'/'+c)
+            self.histos[suff+'FitErr'+'y'+c].GetYaxis().SetRangeUser(0.001,7000)
+            self.canvas[suff+'FitErr'+'y'+c].SetLogy()
+            self.histos[suff+'FitErr'+'y'+c].SetLineWidth(3)
+            self.histos[suff+'FitErr'+'y'+c].SetStats(0)
+            self.histos[suff+'FitErr'+'y'+c].Draw('hist')
+            self.histos[suff+'FitErr'+'y'+c].SetLineColor(self.groupedSystColors['Nominal'][0])
+            self.histos[suff+'FitErrPDF'+'y'+c].SetLineColor(self.groupedSystColors['LHEPdfWeightVars'][0])
+            self.histos[suff+'FitErrScale'+'y'+c].SetLineColor(self.groupedSystColors['LHEScaleWeightVars'][0])
+            self.histos[suff+'FitErrPDF'+'y'+c].SetLineWidth(3)
+            self.histos[suff+'FitErrScale'+'y'+c].SetLineWidth(3)
+            self.histos[suff+'FitErrPDF'+'y'+c].Draw("hist same")
+            self.histos[suff+'FitErrScale'+'y'+c].Draw("hist same")
+            self.leg[suff+'FitErr'+'y'+c].AddEntry(self.histos[suff+'FitErr'+'y'+c],self.groupedSystColors['Nominal'][1])
+            self.leg[suff+'FitErr'+'y'+c].AddEntry(self.histos[suff+'FitErrPDF'+'y'+c],self.groupedSystColors['LHEPdfWeightVars'][1])
+            self.leg[suff+'FitErr'+'y'+c].AddEntry(self.histos[suff+'FitErrScale'+'y'+c],self.groupedSystColors['LHEScaleWeightVars'][1])
+            self.leg[suff+'FitErr'+'y'+c].Draw("Same")
         
         #---------------------------- Canvas correlation matrices ------------------------
         for mtx in ['corr','cov'] :
@@ -751,6 +962,35 @@ class plotter :
             self.leg['comp'+'FitAC'+'UNRyqt'+c].AddEntry(self.histos[suffGen+'FitBand'+'UNRyqt'+c],'Gen Syst')
             self.leg['comp'+'FitAC'+'UNRyqt'+c].Draw("same")
             
+            #integrated
+            self.canvas['comp'+'FitAC'+'qt'+c] = self.canvas[suffGen+'FitAC'+'qt'+c].Clone(self.canvas[suffGen+'FitAC'+'qt'+c].GetName().replace(suffGen,'comp'))
+            self.canvas['comp'+'FitAC'+'qt'+c].SetTitle(self.canvas[suffGen+'FitAC'+'qt'+c].GetTitle().replace(suffGen,'comp'))
+            self.canvas['comp'+'FitAC'+'qt'+c].SetName(self.canvas[suffGen+'FitAC'+'qt'+c].GetName().replace(suffGen,'comp'))
+            self.canvas['comp'+'FitAC'+'qt'+c].cd()
+            self.histos[suffReco+'FitAC'+'qt'+c+'4comp'] = self.histos[suffReco+'FitAC'+'qt'+c].Clone(suffReco+'FitAC'+'qt'+c+'4comp')
+            self.histos[suffReco+'FitAC'+'qt'+c+'4comp'].SetLineColor(ROOT.kGreen-3)
+            self.histos[suffReco+'FitAC'+'qt'+c+'4comp'].Draw("same")
+            self.histos[suffGen+'FitAC'+'qt'+c].DrawCopy("same") #to have foreground
+            self.leg['comp'+'FitAC'+'qt'+c] = ROOT.TLegend(0.6,0.75,0.9,0.9)
+            self.leg['comp'+'FitAC'+'qt'+c].AddEntry(self.histos[suffReco+'FitAC'+'qt'+c+'4comp'],'Reco Asimov')
+            self.leg['comp'+'FitAC'+'qt'+c].AddEntry(self.histos[suffGen+'FitAC'+'qt'+c],'Gen Asimov')
+            self.leg['comp'+'FitAC'+'qt'+c].AddEntry(self.histos[suffGen+'FitBand'+'qt'+c],'Gen Syst')
+            self.leg['comp'+'FitAC'+'qt'+c].Draw("same")
+            
+            self.canvas['comp'+'FitAC'+'y'+c] = self.canvas[suffGen+'FitAC'+'y'+c].Clone(self.canvas[suffGen+'FitAC'+'y'+c].GetName().replace(suffGen,'comp'))
+            self.canvas['comp'+'FitAC'+'y'+c].SetTitle(self.canvas[suffGen+'FitAC'+'y'+c].GetTitle().replace(suffGen,'comp'))
+            self.canvas['comp'+'FitAC'+'y'+c].SetName(self.canvas[suffGen+'FitAC'+'y'+c].GetName().replace(suffGen,'comp'))
+            self.canvas['comp'+'FitAC'+'y'+c].cd()
+            self.histos[suffReco+'FitAC'+'y'+c+'4comp'] = self.histos[suffReco+'FitAC'+'y'+c].Clone(suffReco+'FitAC'+'y'+c+'4comp')
+            self.histos[suffReco+'FitAC'+'y'+c+'4comp'].SetLineColor(ROOT.kGreen-3)
+            self.histos[suffReco+'FitAC'+'y'+c+'4comp'].Draw("same")
+            self.histos[suffGen+'FitAC'+'y'+c].DrawCopy("same") #to have foreground
+            self.leg['comp'+'FitAC'+'y'+c] = ROOT.TLegend(0.6,0.75,0.9,0.9)
+            self.leg['comp'+'FitAC'+'y'+c].AddEntry(self.histos[suffReco+'FitAC'+'y'+c+'4comp'],'Reco Asimov')
+            self.leg['comp'+'FitAC'+'y'+c].AddEntry(self.histos[suffGen+'FitAC'+'y'+c],'Gen Asimov')
+            self.leg['comp'+'FitAC'+'y'+c].AddEntry(self.histos[suffGen+'FitBand'+'y'+c],'Gen Syst')
+            self.leg['comp'+'FitAC'+'y'+c].Draw("same")
+            
             
             #-------------------- Ai errors plots -------------------------------
             
@@ -806,6 +1046,33 @@ class plotter :
             self.leg['comp'+'FitErr'+'UNRyqt'+c].AddEntry(self.histos[suffReco+'FitErr'+'UNRyqt'+c+'4comp'],'Reco Fit Err.')
             self.leg['comp'+'FitErr'+'UNRyqt'+c].Draw("same")
             
+            #integrated
+            self.canvas['comp'+'FitErr'+'qt'+c] = self.canvas[suffGen+'FitErr'+'qt'+c].Clone(self.canvas[suffGen+'FitErr'+'qt'+c].GetName().replace(suffGen,'comp'))
+            self.canvas['comp'+'FitErr'+'qt'+c].SetTitle(self.canvas[suffGen+'FitErr'+'qt'+c].GetTitle().replace(suffGen,'comp'))
+            self.canvas['comp'+'FitErr'+'qt'+c].SetName(self.canvas[suffGen+'FitErr'+'qt'+c].GetName().replace(suffGen,'comp'))
+            self.canvas['comp'+'FitErr'+'qt'+c].cd()
+            self.histos[suffReco+'FitErr'+'qt'+c+'4comp'] = self.histos[suffReco+'FitErr'+'qt'+c].Clone(suffReco+'FitErr'+'qt'+c+'4comp')
+            self.histos[suffReco+'FitErr'+'qt'+c+'4comp'].SetLineColor(ROOT.kGreen-3)
+            self.histos[suffReco+'FitErr'+'qt'+c+'4comp'].Draw("same")
+            self.histos[suffGen+'FitErr'+'qt'+c].DrawCopy("same") #to have foreground
+            
+            self.leg['comp'+'FitErr'+'qt'+c] = self.leg[suffGen+'FitErr'+'qt'+c].Clone()
+            self.leg['comp'+'FitErr'+'qt'+c].AddEntry(self.histos[suffReco+'FitErr'+'qt'+c+'4comp'],'Reco Fit Err.')
+            self.leg['comp'+'FitErr'+'qt'+c].Draw("same")
+            
+            self.canvas['comp'+'FitErr'+'y'+c] = self.canvas[suffGen+'FitErr'+'y'+c].Clone(self.canvas[suffGen+'FitErr'+'y'+c].GetName().replace(suffGen,'comp'))
+            self.canvas['comp'+'FitErr'+'y'+c].SetTitle(self.canvas[suffGen+'FitErr'+'y'+c].GetTitle().replace(suffGen,'comp'))
+            self.canvas['comp'+'FitErr'+'y'+c].SetName(self.canvas[suffGen+'FitErr'+'y'+c].GetName().replace(suffGen,'comp'))
+            self.canvas['comp'+'FitErr'+'y'+c].cd()
+            self.histos[suffReco+'FitErr'+'y'+c+'4comp'] = self.histos[suffReco+'FitErr'+'y'+c].Clone(suffReco+'FitErr'+'y'+c+'4comp')
+            self.histos[suffReco+'FitErr'+'y'+c+'4comp'].SetLineColor(ROOT.kGreen-3)
+            self.histos[suffReco+'FitErr'+'y'+c+'4comp'].Draw("same")
+            self.histos[suffGen+'FitErr'+'y'+c].DrawCopy("same") #to have foreground
+            
+            self.leg['comp'+'FitErr'+'y'+c] = self.leg[suffGen+'FitErr'+'y'+c].Clone()
+            self.leg['comp'+'FitErr'+'y'+c].AddEntry(self.histos[suffReco+'FitErr'+'y'+c+'4comp'],'Reco Fit Err.')
+            self.leg['comp'+'FitErr'+'y'+c].Draw("same")
+            
 
     def makeRootOutput(self,outFileName,SAVE, suffList, comparison) :
 
@@ -828,6 +1095,10 @@ class plotter :
             dirFinalDict['coeff'+suff] = outFile.mkdir('coeff_'+suff)
             dirFinalDict['coeff'+suff].cd()
             for c in self.coeffDict:
+                self.canvas[suff+'FitAC'+'qt'+c].Write()
+                self.canvas[suff+'FitErr'+'qt'+c].Write()
+                self.canvas[suff+'FitAC'+'y'+c].Write()
+                self.canvas[suff+'FitErr'+'y'+c].Write()
                 for i in range(1, self.histos[suff+'FitAC'+c].GetNbinsX()+1):
                     self.canvas[suff+'FitAC'+'qt'+str(i)+c].Write()
                     self.canvas[suff+'FitErr'+'qt'+str(i)+c].Write()
@@ -858,6 +1129,10 @@ class plotter :
             dirFinalDict['comparison_coeff'] = outFile.mkdir('comparison_coeff')
             dirFinalDict['comparison_coeff'].cd()
             for c in self.coeffDict:
+                self.canvas['comp'+'FitAC'+'qt'+c].Write()
+                self.canvas['comp'+'FitErr'+'qt'+c].Write()
+                self.canvas['comp'+'FitAC'+'y'+c].Write()
+                self.canvas['comp'+'FitErr'+'y'+c].Write()
                 for i in range(1, self.histos[suff+'FitAC'+c].GetNbinsX()+1):
                     self.canvas['comp'+'FitAC'+'qt'+str(i)+c].Write()
                     self.canvas['comp'+'FitErr'+'qt'+str(i)+c].Write()
@@ -890,16 +1165,31 @@ def saver(rootInput, suffList, comparison,coeffDict,yArr,qtArr) :
     if not os.path.exists(rootInput): os.system("mkdir -p " + rootInput)
     FitFile = ROOT.TFile.Open(rootInput+'.root')
         
-    compList = ['UNRqty','Err_UNRqty','UNRyqt','Err_UNRyqt']
+    unrList = ['UNRqty','Err_UNRqty','UNRyqt','Err_UNRyqt']
+    intList = ['QT','Y']
 
     if comparison :
         for c in coeffDict:
-            for name in compList :
+            for name in unrList :
                 can = FitFile.Get('comparison_coeff_unrolled/comp_c_'+name+c)
                 can.SaveAs(rootInput+'/'+can.GetTitle()+'.pdf')
                 can.SaveAs(rootInput+'/'+can.GetTitle()+'.png')
     
     for suff in suffList : 
+        
+        if not comparison :
+             for c in coeffDict:
+                for name in unrList :
+                    can = FitFile.Get('coeff_unrolled'+suff+'/'+suff+'_c_'+name+c)
+                    can.SaveAs(rootInput+'/'+can.GetTitle()+'.pdf')
+                    can.SaveAs(rootInput+'/'+can.GetTitle()+'.png')
+                for name in intList :
+                    for ee in ['','_Err'] :
+                        can = FitFile.Get('coeff_'+suff+'/'+suff+'_c_'+name+c+ee)
+                        can.SaveAs(rootInput+'/'+can.GetTitle()+'.pdf')
+                        can.SaveAs(rootInput+'/'+can.GetTitle()+'.png')
+            
+        
         for mtx in ['corr','cov'] :
             for c in coeffDict:
                 can = FitFile.Get('matrices_'+suff+'/'+suff+'_'+mtx+'Mat_'+c)
@@ -929,10 +1219,11 @@ parser = argparse.ArgumentParser("")
 
 parser.add_argument('-o','--output', type=str, default='fitResult',help="name of the output file")
 parser.add_argument('-f','--fitFile', type=str, default='fit_Wplus.root',help="name of the fit result root file. If comparison active the name must be: NAME.root, NAME_reco.root")
-parser.add_argument('-i','--input', type=str, default='../analysisOnGen/genInputUncorr.root',help="name of the input root file")
+parser.add_argument('-i','--input', type=str, default='../analysisOnGen/genInput.root',help="name of the input root file")
 parser.add_argument('-u','--uncorrelate', type=int, default=True,help="if true uncorrelate num and den of Angular Coeff in MC scale variation")
 parser.add_argument('-c','--comparison', type=int, default=True,help="comparison between reco and gen fit")
 parser.add_argument('-s','--save', type=int, default=False,help="save .png and .pdf canvas")
+parser.add_argument('-l','--suffList', type=str, default='',nargs='*', help="list of suff to be processed in the form: gen,reco")
 
 args = parser.parse_args()
 OUTPUT = args.output
@@ -941,13 +1232,15 @@ INPUT = args.input
 UNCORR = args.uncorrelate
 COMP = args.comparison
 SAVE= args.save
+SUFFL =args.suffList
+
 
 p=plotter()
-p.AngCoeffPlots(inputFile=INPUT, fitFile=FITFILE, uncorrelate=UNCORR,suff='gen')
+p.AngCoeffPlots(inputFile=INPUT, fitFile=FITFILE, uncorrelate=UNCORR,suff=SUFFL[0])
 if COMP :
-    recoFit = FITFILE.replace('.root', '_reco.root')
-    p.AngCoeffPlots(inputFile=INPUT, fitFile=recoFit, uncorrelate=UNCORR, suff='reco')
+    recoFit = FITFILE.replace('.root', '_'+str(SUFFL[1])+'.root')
+    p.AngCoeffPlots(inputFile=INPUT, fitFile=recoFit, uncorrelate=UNCORR, suff=SUFFL[1])
     p.GenRecoComparison(suffGen='gen', suffReco='reco')
-p.makeRootOutput(outFileName=OUTPUT, SAVE=SAVE,suffList=['gen','reco'],comparison=COMP)
+p.makeRootOutput(outFileName=OUTPUT, SAVE=SAVE,suffList=SUFFL,comparison=COMP)
 if SAVE :
-    saver(rootInput=OUTPUT,suffList=['gen','reco'],comparison=COMP,coeffDict=p.getCoeffDict(),yArr=p.getYArr(),qtArr=p.getQtArr())
+    saver(rootInput=OUTPUT,suffList=SUFFL,comparison=COMP,coeffDict=p.getCoeffDict(),yArr=p.getYArr(),qtArr=p.getQtArr())

--- a/analysisOnGen/Makefile
+++ b/analysisOnGen/Makefile
@@ -1,5 +1,5 @@
 GCC=g++
-CXXFLAGS=`root-config --libs --cflags` -O3 -fPIC -Wall -I../  -I./  -I /scratchnvme/sroychow/eigen-3.3.7/
+CXXFLAGS=`root-config --libs --cflags` -O3 -fPIC -Wall -I../  -I./  -I /scratchnvme/wmass/eigen-3.3.7/
 SOFLAGS=-shared
 
 SRCDIR=src
@@ -33,7 +33,7 @@ $(OBJ) : $(BINDIR)/%.o : $(SRCDIR)/%.cpp interface/%.hpp | $(BINDIR)
 Dict: $(BINDIR)/dict.o
 
 $(BINDIR)/dict.o: $(SRC) | $(BINDIR)
-	genreflex $(SRCDIR)/classes.h -s $(SRCDIR)/classes_def.xml -o $(BINDIR)/dict.cc --fail_on_warnings --rootmap=$(BINDIR)/dict.rootmap --rootmap-lib=libSignalAnalysis.so -I interface/ -I../ -I /scratchnvme/sroychow/eigen-3.3.7
+	genreflex $(SRCDIR)/classes.h -s $(SRCDIR)/classes_def.xml -o $(BINDIR)/dict.cc --fail_on_warnings --rootmap=$(BINDIR)/dict.rootmap --rootmap-lib=libSignalAnalysis.so -I interface/ -I../ -I /scratchnvme/wmass/eigen-3.3.7
 	$(GCC) -c -o $(BINDIR)/dict.o $(CXXFLAGS) $(RPATH) -I interface $(BINDIR)/dict.cc
 
 $(BINDIR):

--- a/analysisOnGen/interface/AngCoeff.hpp
+++ b/analysisOnGen/interface/AngCoeff.hpp
@@ -9,6 +9,8 @@ class AngCoeff : public Module
 private:
   std::vector<float> _yArr = {0, 0.4, 0.8, 1.2, 1.6, 2.0, 2.4, 3.0, 6.0};
   std::vector<float> _ptArr = {0., 4., 8., 12., 16., 20., 24., 28., 32., 40., 60., 100., 200.};
+  // std::vector<float> _yArr = {0,0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 3.0, 6.0};
+  // std::vector<float> _ptArr = {0. ,2., 4., 6., 8., 10., 12., 14., 16., 18., 20., 22., 24., 26., 28., 30., 32., 40., 60., 100., 200.};
 
   int _nBinsY = 8;
   int _nBinsPt = 12;

--- a/analysisOnGen/runAnalysisOnGen.py
+++ b/analysisOnGen/runAnalysisOnGen.py
@@ -28,7 +28,7 @@ args = parser.parse_args()
 runAC = args.runAC
 runTemplates = args.runTemplates
 
-inputFile = 'test_tree_*.root'
+inputFile = '/scratchnvme/wmass/WJetsNoCUT_v2/tree_*_*.root'
 
 p = RDFtree(outputDir = 'GenInfo', inputFile = inputFile, outputFile="genInfo.root")
 p.branch(nodeToStart = 'input', nodeToEnd = 'basicSelection', modules = [getLumiWeight(xsec=61526.7, inputFile=inputFile), ROOT.baseDefinitions(),ROOT.defineHarmonics(),ROOT.Replica2Hessian(),ROOT.accMap(),ROOT.reweightFromZ(filePt,fileY)])

--- a/analysisOnGen/scripts/prepareAngularCoeff.py
+++ b/analysisOnGen/scripts/prepareAngularCoeff.py
@@ -75,6 +75,8 @@ for sKind, sList in systDict.iteritems():
         
     for sName in sListMod :
             hDict[sName+'mapTot'].Write()
+            hDict[sName+'Y'].Write()
+            hDict[sName+'Pt'].Write()
             for sNameDen in sListMod :
                 if sNameDen!=sName and not (sKind=='_LHEScaleWeight' and UNCORR) : #PDF or correlated Scale
                     continue 
@@ -112,7 +114,7 @@ for sKind, sList in systDict.iteritems():
                                 A_err = math.sqrt(f2w - fw2)/math.sqrt(N_eff)
                                 A_err = A_err*div
                                 if coeff=='A0' :
-                                    A_err = 20./3*(A_err+1./10.)
+                                    A_err = 20./3*(A_err)
                                 hist.SetBinError(xx,yy, A_err )
                     
                     # if sKind=="" :
@@ -155,8 +157,7 @@ mapTot.Write()
 mapAccEta.Write()
 mapAcc.Write()
 sumw.Write()
-#hDict[sName+'Y'].Write()
-#hDict[sName+'Pt'].Write()
+
 
 outFile.Close()
 

--- a/analysisOnGen/src/reweightFromZ.cpp
+++ b/analysisOnGen/src/reweightFromZ.cpp
@@ -1,5 +1,5 @@
 #include "interface/reweightFromZ.hpp"
-#include "interface/functions.hpp"
+// #include "interface/functions.hpp"
 
 RNode reweightFromZ::run(RNode d)
 {

--- a/regularization/regFit_jobLauncher.py
+++ b/regularization/regFit_jobLauncher.py
@@ -1,35 +1,41 @@
 import os
 import sys
-import json
-import argparse
-import ROOT
-import pprint 
-import math
-import numpy as np
-from array import array
-import scipy
-import copy
-from scipy import special
-from scipy import stats
+import regularizationFit
 
-#scale
-LHElist = ["muR0p5_muF0p5", "muR0p5_muF1p0", "muR1p0_muF0p5","muR1p0_muF2p0","muR2p0_muF1p0","muR2p0_muF2p0"]
-for syst in LHElist :
-    print "lounching", syst, "..."
-    os.system('nohup python regularizationFit.py --validation_only 0 -o TEST_syst --map01 0 --syst_kind LHEScaleWeight --syst_name '+syst+' > log_LHEScaleWeights_'+syst+'.log 2>&1 &')
+systDict = regularizationFit.buildSystDict()
+
+for sKind, sList in systDict.iteritems() :
+    for sName in sList :
+        print "lounching", sKind, sName, "..."
+        if sKind=='' and sName=='_nom_nom' :
+            systString = ''
+        else :
+            systString = '--syst_kind '+sKind+' --syst_name '+sName 
+        # if 'Pdf' in sKind : continue  
+        # if 'nom' not in sName : continue 
+        os.system('nohup python regularizationFit.py --validation_only 0 -o TEST_syst --map01 0 '+systString+' -i ../analysisOnGen/genInputUncorrErr_fineBinning.root > log_'+sKind+sName+'.log 2>&1 &')
+
+
+
+
+# #scale
+# LHElist = ["muR0p5_muF0p5", "muR0p5_muF1p0", "muR1p0_muF0p5","muR1p0_muF2p0","muR2p0_muF1p0","muR2p0_muF2p0"]
+# for syst in LHElist :
+#     print "lounching", syst, "..."
+#     os.system('nohup python regularizationFit.py --validation_only 0 -o TEST_syst --map01 0 --syst_kind LHEScaleWeight --syst_name '+syst+' > log_LHEScaleWeights_'+syst+'.log 2>&1 &')
     
-    # rebuild
-    # os.system('nohup python regularizationFit.py --validation_only 1 -o TEST_syst_scale --map01 0 --syst_kind LHEScaleWeight --syst_name '+syst+' --input_name regularizationFit_range11__LHEScaleWeight_'+syst+' > log_LHEScaleWeights_'+syst+'.log 2>&1 &')
+#     # rebuild
+#     # os.system('nohup python regularizationFit.py --validation_only 1 -o TEST_syst_scale --map01 0 --syst_kind LHEScaleWeight --syst_name '+syst+' --input_name regularizationFit_range11__LHEScaleWeight_'+syst+' > log_LHEScaleWeights_'+syst+'.log 2>&1 &')
     
 
-#PDF
-PDFList = ['alphaSDown','alphaSUp']
-# for i in range(1,30) : #needed to avoid to use 101 CPU
-# for i in range(30,60) :
-# for i in range(60,100) :
-PDFList = []
-for i in range(1,100) :
-    PDFList.append(str(i)+'replica')
-for syst in PDFList :
-    print "lounching", syst, "..."
-    os.system('nohup python regularizationFit.py --validation_only 0 -o TEST_syst_PDF --map01 0 --syst_kind LHEPdfWeight --syst_name '+syst+' > log_LHEPdfWeight_'+syst+'.log 2>&1 &')
+# #PDF
+# PDFList = ['alphaSDown','alphaSUp']
+# # for i in range(1,30) : #needed to avoid to use 101 CPU
+# # for i in range(30,60) :
+# # for i in range(60,100) :
+# PDFList = []
+# for i in range(1,100) :
+#     PDFList.append(str(i)+'replica')
+# for syst in PDFList :
+#     print "lounching", syst, "..."
+#     os.system('nohup python regularizationFit.py --validation_only 0 -o TEST_syst_PDF --map01 0 --syst_kind LHEPdfWeight --syst_name '+syst+' > log_LHEPdfWeight_'+syst+'.log 2>&1 &')


### PR DESCRIPTION
In this pr is included:
- regularization update to the new FW. to produce the input for regularization you must use the (commented) binning added in analysisOnGen
- big update of prepareAngularCoeff and plotter_fitResult. to use them:

from analysisOnGen/ 
python scripts/prepareAngularCoeff.py -o genInputFileName -i GenInfoPath/Name.root

from Fit/
 python plotter_fitResult.py -o outPutFileName -f /scratchnvme/emanca/wproperties-analysis/Fit/fit_Wplus_reco.root -u 1 -c 0 -s 0 -i ../analysisOnGen/genInputFileName.root --suffList reco

Other advanced usages are available. For instance, the plotter with c=1 and --suffList gen, reco can be used to compare reco and gen fit. 