### PR TITLE
Move filters to a separate module

### DIFF
--- a/analysisOnData/interface/filter.hpp
+++ b/analysisOnData/interface/filter.hpp
@@ -1,0 +1,18 @@
+#ifndef FILTER_H
+#define FILTER_H
+
+#include "module.hpp"
+
+class EventFilter : public Module
+{
+
+public:
+    EventFilter(){
+    };
+    ~EventFilter(){};
+
+    RNode run(RNode) override;
+
+};
+
+#endif

--- a/analysisOnData/runAnalysisOnMC.py
+++ b/analysisOnData/runAnalysisOnMC.py
@@ -26,18 +26,19 @@ def RDFprocess(fvec, outputDir, sample, xsec, fileSF, systType, pretendJob):
     isoBins = ROOT.vector('float')([0.,0.15,1.])
 
     if systType == 0: #this is data
-        p.branch(nodeToStart='input', nodeToEnd='defs', modules=[ROOT.baseDefinitions(False, False)])
+        p.branch(nodeToStart='input', nodeToEnd='defs', modules=[ROOT.baseDefinitions(False, False), ROOT.EventFilter()])
         p.Histogram(columns = ["Mu1_eta","Mu1_pt","Mu1_charge","MT","Mu1_relIso"], types = ['float']*5,node='defs',histoname=ROOT.string("test"),bins = [etaBins,ptBins,chargeBins,mTBins,isoBins])
         return p
     elif systType < 2: #this is MC with no PDF variations
-        p.branch(nodeToStart = 'input', nodeToEnd = 'defs', modules = [ROOT.baseDefinitions(True, False),ROOT.weightDefinitions(fileSF),getLumiWeight(xsec=xsec, inputFile=fvec)])
+        p.branch(nodeToStart = 'input', nodeToEnd = 'defs', modules = [ROOT.baseDefinitions(True, False),ROOT.EventFilter(),ROOT.weightDefinitions(fileSF),getLumiWeight(xsec=xsec, inputFile=fvec)])
     else:
-        p.branch(nodeToStart = 'input', nodeToEnd = 'defs', modules = [ROOT.baseDefinitions(True, False),ROOT.weightDefinitions(fileSF),getLumiWeight(xsec=xsec, inputFile=fvec),ROOT.Replica2Hessian()])
+        p.branch(nodeToStart = 'input', nodeToEnd = 'defs', modules = [ROOT.baseDefinitions(True, False),ROOT.EventFilter(), ROOT.weightDefinitions(fileSF),getLumiWeight(xsec=xsec, inputFile=fvec),ROOT.Replica2Hessian()])
     p.Histogram(columns = ["Mu1_eta","Mu1_pt","Mu1_charge","MTVars","Mu1_relIso", "lumiweight", "PrefireWeight", "puWeight", "WHSFVars"], types = ['float']*9,node='defs',histoname=ROOT.string("test"),bins = [etaBins,ptBins,chargeBins,mTBins,isoBins])
     return p
 def main():
     parser = argparse.ArgumentParser("")
     parser.add_argument('-p', '--pretend',type=bool, default=False, help="run over a small number of event")
+    parser.add_argument('-r', '--report',type=bool, default=False, help="Prints the cut flow report for all named filters")
     parser.add_argument('-o', '--outputDir',type=str, default='./output/', help="output dir name")
     parser.add_argument('-i', '--inputDir',type=str, default='/scratchnvme/wmass/NanoAOD2016-V2/', help="input dir name")    
 
@@ -98,6 +99,9 @@ def main():
         print(sample)
         #RDFtrees[sample].getOutput()
         RDFtrees[sample].gethdf5Output()
+        if args.report: 
+            RDFtrees[sample].getCutFlowReport()
+
     print('all samples processed in {} s'.format(time.time()-start))
 if __name__ == "__main__":
     main()

--- a/analysisOnData/runAnalysisOnMC.py
+++ b/analysisOnData/runAnalysisOnMC.py
@@ -26,15 +26,29 @@ def RDFprocess(fvec, outputDir, sample, xsec, fileSF, systType, pretendJob):
     isoBins = ROOT.vector('float')([0.,0.15,1.])
 
     if systType == 0: #this is data
-        p.branch(nodeToStart='input', nodeToEnd='defs', modules=[ROOT.baseDefinitions(False, False), ROOT.EventFilter()])
+        p.branch(nodeToStart='input', nodeToEnd='defs', modules=[ROOT.baseDefinitions(False, False)])
+        p.EventFilter(nodeToStart='defs', nodeToEnd='filtered', evfilter="HLT_SingleMu24", filtername="Pass HLT")
+        p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="(Vtype==0 || Vtype==1)", filtername="Vtype selection")
+        p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="HLT_SingleMu24", filtername="Pass HLT")
+        p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="MET_filters==1", filtername="Pass MET filter")
+        p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="nVetoElectrons==0", filtername="Electron veto")
+        p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="Idx_mu1>-1", filtername="Event has atleast 1 muon")
         p.Histogram(columns = ["Mu1_eta","Mu1_pt","Mu1_charge","MT","Mu1_relIso"], types = ['float']*5,node='defs',histoname=ROOT.string("test"),bins = [etaBins,ptBins,chargeBins,mTBins,isoBins])
         return p
     elif systType < 2: #this is MC with no PDF variations
-        p.branch(nodeToStart = 'input', nodeToEnd = 'defs', modules = [ROOT.baseDefinitions(True, False),ROOT.EventFilter(),ROOT.weightDefinitions(fileSF),getLumiWeight(xsec=xsec, inputFile=fvec)])
+        p.branch(nodeToStart = 'input', nodeToEnd = 'defs', modules = [ROOT.baseDefinitions(True, False),ROOT.weightDefinitions(fileSF),getLumiWeight(xsec=xsec, inputFile=fvec)])
     else:
-        p.branch(nodeToStart = 'input', nodeToEnd = 'defs', modules = [ROOT.baseDefinitions(True, False),ROOT.EventFilter(), ROOT.weightDefinitions(fileSF),getLumiWeight(xsec=xsec, inputFile=fvec),ROOT.Replica2Hessian()])
+        p.branch(nodeToStart = 'input', nodeToEnd = 'defs', modules = [ROOT.baseDefinitions(True, False),ROOT.weightDefinitions(fileSF),getLumiWeight(xsec=xsec, inputFile=fvec),ROOT.Replica2Hessian()])
+    
+    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="HLT_SingleMu24", filtername="Pass HLT")
+    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="(Vtype==0 || Vtype==1)", filtername="Vtype selection")
+    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="HLT_SingleMu24", filtername="Pass HLT")
+    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="MET_filters==1", filtername="Pass MET filter")
+    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="nVetoElectrons==0", filtername="Electron veto")
+    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="Idx_mu1>-1", filtername="Event has atleast 1 muon")
     p.Histogram(columns = ["Mu1_eta","Mu1_pt","Mu1_charge","MTVars","Mu1_relIso", "lumiweight", "PrefireWeight", "puWeight", "WHSFVars"], types = ['float']*9,node='defs',histoname=ROOT.string("test"),bins = [etaBins,ptBins,chargeBins,mTBins,isoBins])
     return p
+
 def main():
     parser = argparse.ArgumentParser("")
     parser.add_argument('-p', '--pretend',type=bool, default=False, help="run over a small number of event")
@@ -46,7 +60,7 @@ def main():
     pretendJob = args.pretend
     outputDir = args.outputDir
     inDir = args.inputDir
-
+    print("Print report?>>>{}".format(args.report))
     if pretendJob:
         print("Running a test job over a few events")
     else:

--- a/analysisOnData/src/baseDefinitions.cpp
+++ b/analysisOnData/src/baseDefinitions.cpp
@@ -5,9 +5,7 @@ RNode baseDefinitions::run(RNode d)
 {
     //define all nominal quantities // true for data and MC
 
-    auto d1 = d.Filter("(Vtype==0 || Vtype==1) && HLT_SingleMu24 && MET_filters==1 && nVetoElectrons==0")
-                  .Filter("Idx_mu1>-1")
-                  .Define("Mu1_eta", getFromIdx, {"Muon_eta", "Idx_mu1"})
+    auto d1 = d.Define("Mu1_eta", getFromIdx, {"Muon_eta", "Idx_mu1"})
                   .Define("Mu1_phi", getFromIdx, {"Muon_phi", "Idx_mu1"})
                   .Define("Mu1_charge", getCharge, {"Muon_charge", "Idx_mu1"})
                   .Define("Mu1_relIso", getFromIdx, {"Muon_pfRelIso04_all", "Idx_mu1"})

--- a/analysisOnData/src/classes.h
+++ b/analysisOnData/src/classes.h
@@ -7,3 +7,4 @@
 #include "getMassWeights.hpp"
 #include "getWeights.hpp"
 #include "defineHarmonics.hpp"
+#include "filter.hpp"

--- a/analysisOnData/src/classes_def.xml
+++ b/analysisOnData/src/classes_def.xml
@@ -8,4 +8,5 @@
   <class name="getMassWeights"/>
   <class name="getWeights"/>
   <class name="defineHarmonics"/>
+  <class name="EventFilter"/>
 </lcgdict>

--- a/analysisOnData/src/filter.cpp
+++ b/analysisOnData/src/filter.cpp
@@ -1,0 +1,13 @@
+#include "filter.hpp"
+
+RNode EventFilter::run(RNode d)
+{
+  auto d1 = d
+    .Filter("(Vtype==0 || Vtype==1)", "Vtype selection")
+    .Filter("HLT_SingleMu24", "Pass HLT")
+    .Filter("MET_filters==1", "Pass MET filter")
+    .Filter("nVetoElectrons==0", "Electron veto")
+    .Filter("Idx_mu1>-1", "Event has atleast 1 muon");
+  return d1;
+                  
+}


### PR DESCRIPTION
Basic filters are moved to a separate module. Option to print cut flow report has been implemented in RDFtree(will need this [PR](https://github.com/emanca/RDFprocessor/pull/32) ).

Further developments needed for Signal only filters when making low acc templates. 