### PR TITLE
Updating lumiweight module

### DIFF
--- a/Common/data/genSumWClipped.py
+++ b/Common/data/genSumWClipped.py
@@ -1,0 +1,14 @@
+sumwClippedDict = {
+    "DYJetsToMuMu_M50": 236002045557.625, 
+    "DYJetsToTauTau_M50": 117743596494.25, 
+    "WPlusJetsToMuNu": 5895447715506.5, 
+    "WMinusJetsToMuNu": 2001441443604.5, 
+    "WPlusJetsToTauNu": 805327017069.5, 
+    "WMinusJetsToTauNu": 357288521895.0, 
+    "WZ": 680128.0, 
+    "WW": 1843183.250793457, 
+    "ST_t-channel_top_5f_InclusiveDecays": 394691602.59375, 
+    "ST_t-channel_tauDecays": 12390.0, 
+    "ST_t-channel_muDecays": 254958.0, 
+    "ST_s-channel_4f_leptonDecays": 3687399.50390625
+}

--- a/Common/data/samples_2016_ul.py
+++ b/Common/data/samples_2016_ul.py
@@ -4,10 +4,15 @@ samplespreVFP = {
         "xsec": -1, 
         "dir": ["Run2016B", "Run2016C", "Run2016D", "Run2016E", "Run2016F"]
     },
-    "DYJetsToLL_M50": {
+    "DYJetsToMuMu_M50": {
         "nsyst": 2, 
         "xsec": 1976.17, 
-        "dir": ["DYJetsToMuMu","DYJetsToTauTau"]
+        "dir": ["DYJetsToMuMu"]
+    }, 
+    "DYJetsToTauTau_M50": {
+        "nsyst": 2, 
+        "xsec": 1976.17, 
+        "dir": ["DYJetsToTauTau"]
     }, 
     "WPlusJetsToMuNu": {
         "nsyst": 2, 

--- a/templateMaker/interface/lumiWeight.hpp
+++ b/templateMaker/interface/lumiWeight.hpp
@@ -9,12 +9,14 @@ class lumiWeight : public Module
 private:
     float _targetLumi;
     float _xsec;
+    float _genEventSumwClipped;
 
 public:
-    lumiWeight(float xsec, float targetLumi = 35.9)
+  lumiWeight(float xsec, float sumwclipped, float targetLumi = 35.9)
     {
         _targetLumi = targetLumi;
         _xsec = xsec/ 0.001;
+        _genEventSumwClipped = sumwclipped;
     };
 
     ~lumiWeight(){};

--- a/templateMaker/src/lumiWeight.cpp
+++ b/templateMaker/src/lumiWeight.cpp
@@ -8,10 +8,9 @@ RNode lumiWeight::run(RNode d)
         return sign * new_weight;
     };
 
-    // float genEventSumw = d.Define("Generator_weight_clipped", clipGenWeight, {"Generator_weight"}).Sum("Generator_weight_clipped").GetValue();
-    //float genEventSumw = 5.89545e+12; // W gensumw
-    float genEventSumw = 3.53746e+11; // Z gensumw
-    auto d1 = d.Define("Generator_weight_clipped", clipGenWeight, {"Generator_weight"}).Define("lumiweight", Form("float((%f*%f*Generator_weight_clipped)/(%f))", _targetLumi, _xsec, genEventSumw));
+    //auto d1 = d.Define("Generator_weight_clipped", clipGenWeight, {"Generator_weight"}).Define("lumiweight", Form("float((%f*%f*Generator_weight_clipped)/(%f))", _targetLumi, _xsec, genEventSumw));
+    //_genEventSumwClipped=3.53746e+10;
+    auto d1 = d.Define("Generator_weight_clipped", clipGenWeight, {"Generator_weight"}).Define("lumiweight", Form("float((%f*%f*Generator_weight_clipped)/(%f))", _targetLumi, _xsec, _genEventSumwClipped));
 
     return d1;
 }


### PR DESCRIPTION
1. A dictionary of sample vs genEventSum added
2. Lumiweight module now accepts the pre-computed sum and  calculates the event weight.
3. DYJetsTauTau and DYJetsMuMu are treated as separate sample.
4. The default lumi in the runBkg_ul.py is set to 19.3 for preVFP era.