### PR TITLE
alternate W and Z samples

### DIFF
--- a/Common/data/samples_2016_ul_alternate.py
+++ b/Common/data/samples_2016_ul_alternate.py
@@ -1,0 +1,38 @@
+samplespreVFP = {
+    "data": {
+        "nsyst": 0, 
+        "xsec": -1, 
+        "dir": ["Run2016B", "Run2016C", "Run2016D", "Run2016E", "Run2016F"]
+    },
+    "DYJetsToLL_M50": {
+        "nsyst": 2, 
+        "xsec": 7181.0, 
+        "dir": ["../alternate/DYJetsToLL-M50"]
+    }, 
+    "WJetsToLNu": {
+        "nsyst": 2, 
+        "xsec": 60890.0, 
+        "dir": ["../alternate/WJetsToLNu_madgraph"]
+    },
+}
+
+samplesPostVFP = {
+    "data": {
+        "nsyst": 0, 
+        "xsec": -1, 
+        "dir": ["Run2016F_postVFP", "Run2016G", "Run2016H"]
+    },
+    "DYJetsToLL_M50": {
+        "nsyst": 2, 
+        "xsec": 7181.0, 
+        "dir": ["../alternate/DYJetsToLL-M50"]
+    }, 
+    "WJetsToLNu": {
+        "nsyst": 2, 
+        "xsec": 60890.0, 
+        "dir": ["../alternate/WJetsToLNu_madgraph"]
+    },
+}
+
+'''
+'''


### PR DESCRIPTION
Adding a samples config for alternate W & Z samples.

Applying the clipping logic to genEvweights, the sums are as follows:-

DY = 1805550943.0                           (original sum = 1805579791.5359998)(ratio ~1)
WJets=4394327915173.582              (original sum = 10596622197027.643)(ratio ~  0.415)