### PR TITLE
Sync Z studies with CERN

### DIFF
--- a/Common/data/genSumWClipped.py
+++ b/Common/data/genSumWClipped.py
@@ -1,6 +1,18 @@
+#using genWeight as the branch
 sumwClippedDict = {
-    "DYJetsToMuMu_M50": 236002045557.625, 
-    "DYJetsToTauTau_M50": 117743596494.25, 
+    "DYJetsToMuMu_M50": 235996573447.5537,
+    "DYJetsToTauTau_M50": 117740866311.92139,
+    "WPlusJetsToMuNu": 5895489808249.853,
+    "WMinusJetsToMuNu": 2001402133898.8691,
+    "WPlusJetsToTauNu": 805332767237.3389,
+    "WMinusJetsToTauNu": 357281504749.76074
+}
+
+'''
+#using Generator weight
+sumwClippedDict = {
+    "DYJetsToMuMu_M50":  236002045557.625, #Marco 2.36619888176e+11,  #236002045557.625, 
+    "DYJetsToTauTau_M50": 117743596494.25, #Marco 1.17935409707e+11, #117743596494.25, 
     "WPlusJetsToMuNu": 5895447715506.5, 
     "WMinusJetsToMuNu": 2001441443604.5, 
     "WPlusJetsToTauNu": 805327017069.5, 
@@ -12,3 +24,5 @@ sumwClippedDict = {
     "ST_t-channel_muDecays": 254958.0, 
     "ST_s-channel_4f_leptonDecays": 3687399.50390625
 }
+'''
+

--- a/Common/plotZ.py
+++ b/Common/plotZ.py
@@ -10,7 +10,7 @@ plt.style.use([hep.style.ROOT])
 #hep.cms.label(loc=0, year=2016, lumi=35.9, data=True)
 #hep.cms.text('Simulation')
 
-folder = "../templateMaker/outputDY_31_01_2021_17_59_44/"
+folder = sys.argv[1] #"../templateMaker/outputDY_31_01_2021_17_59_44/"
 
 histonames = ['DY', 'DY_sumw2']
 shape = ((len(zmassBins)-1)*(len(etaBins)-1)*(len(ptBins)-1)*(len(qtBins)-1)*(len(etaBins)-1))

--- a/templateMaker/interface/SF_ul.hpp
+++ b/templateMaker/interface/SF_ul.hpp
@@ -29,7 +29,7 @@ public:
         _trigger_minus = (TH2D *)_SF->Get("SF2D_trigger_BtoF_minus");
         _iso = (TH2D *)_SF->Get("SF2D_iso_BtoF_both");
         _antiiso = (TH2D *)_SF->Get("SF2D_antiiso_BtoF_both");
-	prefCharge = _prefCharge;
+	_prefCharge = prefCharge;
     };
     ~SF_ul(){};
 

--- a/templateMaker/interface/SF_ul.hpp
+++ b/templateMaker/interface/SF_ul.hpp
@@ -15,9 +15,11 @@ private:
     TH2D *_iso;
     TH2D *_antiiso;
     bool _isZ;
+    //this is only relevant for Z studies
+    int _prefCharge;
 
 public:
-    SF_ul(TFile *SF, bool isZ = false)
+  SF_ul(TFile *SF, bool isZ = false, int prefCharge = 1)
     {
         _SF = SF;
         _isZ = isZ;
@@ -27,6 +29,7 @@ public:
         _trigger_minus = (TH2D *)_SF->Get("SF2D_trigger_BtoF_minus");
         _iso = (TH2D *)_SF->Get("SF2D_iso_BtoF_both");
         _antiiso = (TH2D *)_SF->Get("SF2D_antiiso_BtoF_both");
+	prefCharge = _prefCharge;
     };
     ~SF_ul(){};
 

--- a/templateMaker/interface/functions.hpp
+++ b/templateMaker/interface/functions.hpp
@@ -4,6 +4,7 @@
 
 ROOT::VecOps::RVec<float> dummy(ULong64_t event);
 float getFromIdx(ROOT::VecOps::RVec<float> vec, int index);
+int getIntFromIdx(ROOT::VecOps::RVec<int> vec, int index);
 float getCharge(ROOT::VecOps::RVec<int> vec, int idx);
 float W_mt(float,float,float,float);
 float Wlike_mt(float,float,float,float,float,float);

--- a/templateMaker/interface/lumiWeight.hpp
+++ b/templateMaker/interface/lumiWeight.hpp
@@ -9,10 +9,10 @@ class lumiWeight : public Module
 private:
     float _targetLumi;
     float _xsec;
-    float _genEventSumwClipped;
+    double _genEventSumwClipped;
 
 public:
-  lumiWeight(float xsec, float sumwclipped, float targetLumi = 35.9)
+  lumiWeight(float xsec, double sumwclipped, float targetLumi = 35.9)
     {
         _targetLumi = targetLumi;
         _xsec = xsec/ 0.001;

--- a/templateMaker/python/getGenWeightClipped.py
+++ b/templateMaker/python/getGenWeightClipped.py
@@ -1,0 +1,70 @@
+import ROOT
+import json
+import sys
+import os
+
+sys.path.append('../../Common/data')
+
+ROOT.gInterpreter.Declare("""
+#include "ROOT/RDataFrame.hxx"
+#include "ROOT/RDF/RInterface.hxx"
+
+using RNode = ROOT::RDF::RNode;
+
+ROOT::RDF::RResultPtr<double> getClippedSumW(std::vector<std::string> fileNames)
+{
+  auto df = RNode(ROOT::RDataFrame("Events", fileNames));
+
+  auto clipGenWeight = [](float Gen_weight) {
+    double sign = Gen_weight / abs(Gen_weight);
+    //return sign;                                                                                                                                                                                   
+    double new_weight = double(std::min(fabs(Gen_weight), float(50000.)));
+    return sign * new_weight;
+  };
+  //auto d1 = df.Define("Generator_weight_clipped", clipGenWeight, {"Generator_weight"});                                                                                                            
+  auto d1 = df.Define("Generator_weight_clipped", clipGenWeight, {"genWeight"}).Sum<double>("Generator_weight_clipped");
+  return d1;
+}
+""")
+
+from samples_2016_ul import samplespreVFP
+
+def genwtsum(sample, fvec) :
+    print("processing ", sample)
+    
+ROOT.ROOT.EnableImplicitMT(64)
+
+inDir='/scratchnvme/wmass/NanoAOD2016-UL/preVFP/'
+samples = samplespreVFP
+sumwProc={}
+sumwRunProc = {}
+objList = []
+for sample in samples:
+    if 'data' in sample: continue
+    computeYes= 'DY' in sample or 'WPlus' in sample or 'WMinus' in sample
+    if not computeYes : continue
+    fvec=ROOT.vector('string')()
+    direc = samples[sample]['dir']
+    for d in direc:
+        targetDir='{}/{}/merged/'.format(inDir, d)
+        for f in os.listdir(targetDir):
+            if not f.endswith('.root'): continue
+            inputFile=targetDir+f
+            fvec.push_back(inputFile)
+    if fvec.empty():
+        print("No files found for directory:", samples[sample], " SKIPPING processing")
+        continue
+    print(fvec)  
+    sumwProc[sample] = ROOT.getClippedSumW(fvec)
+    objList.append(sumwProc[sample])
+
+ROOT.RDF.RunGraphs(objList)
+
+sumwClipped = {} 
+
+for sample in samples:
+    if sample not in sumwProc.keys() : continue
+    sumwClipped[sample]=sumwProc[sample].GetValue()
+
+with open('genSumWOutput.py', 'w') as fp:
+    json.dump(sumwClipped, fp, indent=4)

--- a/templateMaker/runZ_ul.py
+++ b/templateMaker/runZ_ul.py
@@ -20,27 +20,48 @@ ROOT.gSystem.Load('bin/libAnalysisOnData.so')
 ROOT.gROOT.ProcessLine("gErrorIgnoreLevel = 2001;")
 
 def RDFprocess(fvec, outputDir, sample, xsec, systType, sumwClipped, pretendJob):
+    chargeCut="(Muon_charge[Idx_mu1] > 0 && Muon_hasTriggerMatch[Idx_mu1]) || (Muon_charge[Idx_mu2] > 0 && Muon_hasTriggerMatch[Idx_mu2])"
+    isoCut = "(Muon_charge[Idx_mu1] > 0 && Muon_pfRelIso04_all[Idx_mu1] < 0.15) || (Muon_charge[Idx_mu2] > 0 && Muon_pfRelIso04_all[Idx_mu2] < 0.15)"
     print("processing ", sample)
     p = RDFtree(outputDir = outputDir, inputFile = fvec, outputFile="{}.root".format(sample), pretend=pretendJob)
-    p.EventFilter(nodeToStart='input', nodeToEnd='defs', evfilter="Vtype==2", filtername="{:20s}".format("Vtype multilepton selection"))
-    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="Idx_mu1>-1 && Idx_mu2>-1", filtername="{:20s}".format("Atleast 2 mu"))
-    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="nVetoElectrons==0", filtername="{:20s}".format("Electron veto"))
-    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="HLT_SingleMu24", filtername="{:20s}".format("Pass HLT"))
-    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="Muon_hasTriggerMatch[Idx_mu1] && Muon_hasTriggerMatch[Idx_mu2]", filtername="{:20s}".format("Both mu trigger matched"))
+
+    p.EventFilter(nodeToStart='input', nodeToEnd='defs', evfilter="event%2!=0", filtername="{:20s}".format("Odd event"))
+
+    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="nVetoElectrons== 0 && Idx_mu1>-1 && Idx_mu2>-1", filtername="{:20s}".format("twomuon"))
+
+    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="HLT_SingleMu24 > 0 ", filtername="{:20s}".format("Pass HLT"))
+
+    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter=chargeCut, filtername="{:20s}".format("Trig object matching for preselected leg"))
+
     p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="Vtype_subcat == 0", filtername="{:20s}".format("Opposite Charge and loose isolation"))
+
+    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="abs(Muon_eta[Idx_mu1]) < 2.4 && abs(Muon_eta[Idx_mu2]) < 2.4 && (26. < Muon_pt[Idx_mu1] && Muon_pt[Idx_mu1] < 55.) && (26. < Muon_pt[Idx_mu2] && Muon_pt[Idx_mu2] < 55.)", filtername="{:20s}".format("acceptance"))
+
+    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="{}".format(isoCut), filtername="{:20s}".format("pfRelIso04_mainLeg"))
+
     p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="Muon_mediumId[Idx_mu1] == 1 && Muon_mediumId[Idx_mu2] == 1", filtername="{:20s}".format("MuonID"))
-    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="Muon_pfRelIso04_all[Idx_mu1] < 0.15 && Muon_pfRelIso04_all[Idx_mu2] < 0.15", filtername="{:20s}".format("Both muon pass ISO"))  
+
+    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="abs(Muon_dxy[Idx_mu1]) < 0.05 && abs(Muon_dxy[Idx_mu2]) < 0.05", filtername="{:20s}".format("dxy"))    
+
+    p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="abs(Muon_dz[Idx_mu1]) < 0.05 && abs(Muon_dz[Idx_mu2]) < 0.05", filtername="{:20s}".format("dz"))    
+
     #note for customizeforUL(isMC=true, isWorZ=false)
     if systType == 0: #this is data
         p.branch(nodeToStart='defs', nodeToEnd='defs', modules=[ROOT.customizeforUL(False, False), ROOT.recoDefinitions(False, False)])
         p.branch(nodeToStart='defs', nodeToEnd='defs', modules=[ROOT.getZmass(isData=True)])
         #p.displayColumn(node="defs", columname="dimuonMass")
+
+        p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="60. < dimuonMass && dimuonMass < 120.", filtername="{:20s}".format("mZ range"))
+
         p.Histogram(columns = ["dimuonMass", "Mu1_eta", "Mu1_pt", "dimuonPt", "dimuonY"], types = ['float']*5,node='defs',histoname=ROOT.string('data_obs'),bins = [zmassBins,etaBins, ptBins,qtBins, etaBins], variations = [])
         return p
     else:
         p.branch(nodeToStart = 'defs', nodeToEnd = 'defs', modules = [ROOT.lumiWeight(xsec=xsec, sumwclipped=sumwClipped, targetLumi = 19.3), ROOT.customizeforUL(True, False), ROOT.recoDefinitions(True, False)])
         p.branch(nodeToStart='defs', nodeToEnd='defs', modules=[ROOT.getZmass(),ROOT.SF_ul(fileSFul, isZ=True)])
         #p.displayColumn(node="defs", columname={"dimuonMass", "lumiweight", "puWeight", "SF"})
+
+        p.EventFilter(nodeToStart='defs', nodeToEnd='defs', evfilter="60. < dimuonMass && dimuonMass < 120.", filtername="{:20s}".format("mZ range"))
+
         p.Histogram(columns = ["dimuonMass", "Mu1_eta", "Mu1_pt", "Vpt_preFSR", "Vrap_preFSR", "lumiweight", "puWeight", "SF", "PrefireWeight"], types = ['float']*9,node='defs',histoname=ROOT.string('DY'),bins = [zmassBins,etaBins,ptBins,qtBins, etaBins], variations = [])
         return p
 

--- a/templateMaker/src/SF_ul.cpp
+++ b/templateMaker/src/SF_ul.cpp
@@ -2,39 +2,43 @@
 #include "functions.hpp"
 RNode SF_ul::run(RNode d){
 
-    auto defineSFZ = [this](float pt1, float eta1, float charge1, float iso1, float pt2, float eta2, float charge2, float iso2) {
+  auto defineSFZ = [this](float pt1, float eta1, float charge1, float iso1, int istrigMatched1, float pt2, float eta2, float charge2, float iso2, int istrigMatched2) {
+      /*
+	@SRC Note: here we choose muon of one charge(set from config) as primary or preferred muon in 
+	a dimuon event. This muon is trigger matched. All the SFs shall be applied for this muon. 
+	Whereas, for the other muon, only the tracking and ID SF is appled.
+	**The default charge is +ve;
+      */
 
-        int binTracking1 = _tracking->FindBin(eta1, pt1);
-        int binTrigger1 = _trigger_plus->FindBin(eta1, pt1);
-        int binIso1 = _iso->FindBin(eta1, pt1);
-        int binIdip1 = _idip->FindBin(eta1, pt1);
+      int binTracking1 = _tracking->FindBin(eta1, pt1);
+      int binIdip1 = _idip->FindBin(eta1, pt1);
+      int binTracking2 = _tracking->FindBin(eta2, pt2);
+      int binIdip2 = _idip->FindBin(eta2, pt2);
+      //this is always applied
+      float combinedSF=_tracking->GetBinContent(binTracking1) * _idip->GetBinContent(binIdip1);
+      combinedSF=_tracking->GetBinContent(binTracking2)*_idip->GetBinContent(binIdip2);
 
-        int binTracking2 = _tracking->FindBin(eta2, pt2);
-        int binTrigger2 = _trigger_plus->FindBin(eta2, pt2);
-        int binIso2 = _iso->FindBin(eta2, pt2);
-        int binIdip2 = _idip->FindBin(eta2, pt2);
-
-        float SFiso1 = _iso->GetBinContent(binIso1);
-        float SFiso2 = _iso->GetBinContent(binIso2);
-
-        float SFtrigger1 = -9999999.;
+      if(_prefCharge == charge1 && istrigMatched1 > 0) {
+	int binTrigger1 = _trigger_plus->FindBin(eta1, pt1);
+	int binIso1 = _iso->FindBin(eta1, pt1);
         if (charge1 > 0.)
-            SFtrigger1 = _trigger_plus->GetBinContent(binTrigger1);
+            combinedSF *= _trigger_plus->GetBinContent(binTrigger1);
         else
-            SFtrigger1 = _trigger_minus->GetBinContent(binTrigger1);
-
-        float SFtrigger2 = -9999999.;
+            combinedSF *= _trigger_minus->GetBinContent(binTrigger1);   
+	
+	combinedSF *= _iso->GetBinContent(binIso1);
+      } else if(_prefCharge == charge2 && istrigMatched2 > 0) {
+	int binTrigger2 = _trigger_plus->FindBin(eta2, pt2);
+        int binIso2 = _iso->FindBin(eta2, pt2);	
         if (charge2 > 0.)
-            SFtrigger2 = _trigger_plus->GetBinContent(binTrigger2);
+            combinedSF *= _trigger_plus->GetBinContent(binTrigger2);
         else
-            SFtrigger2 = _trigger_minus->GetBinContent(binTrigger2);
-
-        float SFtracking1 = _tracking->GetBinContent(binTracking1);
-        float SFidip1 = _idip->GetBinContent(binIdip1);
-        float SFtracking2 = _tracking->GetBinContent(binTracking2);
-        float SFidip2 = _idip->GetBinContent(binIdip2);
-
-        return SFtracking1 * SFtrigger1 * SFidip1 * SFiso1 * SFtracking2 * SFtrigger2 * SFidip2 * SFiso2;
+	  combinedSF *= _trigger_minus->GetBinContent(binTrigger2);
+	combinedSF *=_iso->GetBinContent(binIso2);
+      }
+ 
+      //return SFtracking1 * SFtrigger1 * SFidip1 * SFiso1 * SFtracking2 * SFtrigger2 * SFidip2 * SFiso2;
+      return combinedSF;
     };
 
     auto defineSF = [this](float pt1, float eta1, float charge1, float iso1){
@@ -63,7 +67,7 @@ RNode SF_ul::run(RNode d){
     };
 
     if(_isZ){
-        auto d1 = d.Define("SF", defineSFZ, {"Mu1_pt", "Mu1_eta", "Mu1_charge", "Mu1_relIso", "Mu2_pt", "Mu2_eta", "Mu2_charge", "Mu2_relIso"});
+        auto d1 = d.Define("SF", defineSFZ, {"Mu1_pt", "Mu1_eta", "Mu1_charge", "Mu1_relIso", "Mu1_hasTriggerMatch", "Mu2_pt", "Mu2_eta", "Mu2_charge", "Mu2_relIso", "Mu2_hasTriggerMatch"});
         return d1;
     }
     else{

--- a/templateMaker/src/SF_ul.cpp
+++ b/templateMaker/src/SF_ul.cpp
@@ -16,7 +16,7 @@ RNode SF_ul::run(RNode d){
       int binIdip2 = _idip->FindBin(eta2, pt2);
       //this is always applied
       float combinedSF=_tracking->GetBinContent(binTracking1) * _idip->GetBinContent(binIdip1);
-      combinedSF=_tracking->GetBinContent(binTracking2)*_idip->GetBinContent(binIdip2);
+      combinedSF *= _tracking->GetBinContent(binTracking2)*_idip->GetBinContent(binIdip2);
 
       if(_prefCharge == charge1 && istrigMatched1 > 0) {
 	int binTrigger1 = _trigger_plus->FindBin(eta1, pt1);

--- a/templateMaker/src/SF_ul.cpp
+++ b/templateMaker/src/SF_ul.cpp
@@ -67,10 +67,9 @@ RNode SF_ul::run(RNode d){
     };
 
     if(_isZ){
-        auto d1 = d.Define("SF", defineSFZ, {"Mu1_pt", "Mu1_eta", "Mu1_charge", "Mu1_relIso", "Mu1_hasTriggerMatch", "Mu2_pt", "Mu2_eta", "Mu2_charge", "Mu2_relIso", "Mu2_hasTriggerMatch"});
-        return d1;
-    }
-    else{
+      auto d1 = d.Define("SF", defineSFZ, {"Mu1_pt", "Mu1_eta", "Mu1_charge", "Mu1_relIso", "Mu1_hasTriggerMatch", "Mu2_pt", "Mu2_eta", "Mu2_charge", "Mu2_relIso", "Mu2_hasTriggerMatch"});
+      return d1;
+    } else{
         auto d1 = d.Define("SF", defineSF, {"Mu1_pt", "Mu1_eta", "Mu1_charge", "Mu1_relIso"});
         return d1;
     }

--- a/templateMaker/src/functions.cpp
+++ b/templateMaker/src/functions.cpp
@@ -5,6 +5,12 @@
 float getFromIdx(ROOT::VecOps::RVec<float> vec, int index){
 	return vec[index];
 }
+
+int getIntFromIdx(ROOT::VecOps::RVec<int> vec, int index){
+	return vec[index];
+}
+
+
 float getCharge(ROOT::VecOps::RVec<int> vec, int index)
 {
   return float(vec[index]);

--- a/templateMaker/src/getZmass.cpp
+++ b/templateMaker/src/getZmass.cpp
@@ -44,6 +44,7 @@ RNode getZmass::run(RNode d) {
       .Define("Mu2_pt", getFromIdx, {"Muon_corrected_pt", "Idx_mu2"})
       .Define("Mu2_sip3d", getFromIdx, {"Muon_sip3d", "Idx_mu2"})
       .Define("Mu2_dxy", getFromIdx, {"Muon_dxy", "Idx_mu2"})
+      .Define("Mu2_hasTriggerMatch", getIntFromIdx, {"Muon_hasTriggerMatch", "Idx_mu2"})
       .Define("dimuonMass", getdimuonMass, {"Muon_pt", "Muon_eta", "Muon_phi", "Muon_mass", "Idx_mu1", "Idx_mu2"});
   
   if(_isData){

--- a/templateMaker/src/recoDefinitions.cpp
+++ b/templateMaker/src/recoDefinitions.cpp
@@ -13,6 +13,7 @@ RNode recoDefinitions::run(RNode d)
                   .Define("Mu1_pt", getFromIdx, {"Muon_corrected_pt", "Idx_mu1"})
                   .Define("Mu1_sip3d", getFromIdx, {"Muon_sip3d", "Idx_mu1"})
                   .Define("Mu1_dxy", getFromIdx, {"Muon_dxy", "Idx_mu1"})
+                  .Define("Mu1_hasTriggerMatch", getIntFromIdx, {"Muon_hasTriggerMatch", "Idx_mu1"})
                   .Define("MT", W_mt, {"Mu1_pt", "Mu1_phi", "MET_pt_nom", "MET_phi_nom"})
                   .Define("Recoil_pt", W_hpt, {"Mu1_pt", "Mu1_phi", "MET_pt_nom", "MET_phi_nom"});
 


### PR DESCRIPTION
Changes to align cuts for Z studies to CERN group[link](http://mciprian.web.cern.ch/mciprian/wmass/13TeV/testNanoAOD/Wlike/testNewSF/dataBtoH_SFforBtoH_noMtCut_noIsoOnOtherLep_2ormoreMu_v5/oddEvents/plots_test_cuts.txt)

The only difference now is GenEventSumw(~0.2% difference w.r.t CERN). The following plots are from Z config where the preferred charge is +ve. 

![mass_iso1_1_iso2_1](https://user-images.githubusercontent.com/6286474/106528545-35573f80-64e9-11eb-8fc1-773bcd37bbe0.png)
![eta_iso1_1_iso2_1](https://user-images.githubusercontent.com/6286474/106528551-38523000-64e9-11eb-93bb-f0e1c508e426.png)
![pt_iso1_1_iso2_1](https://user-images.githubusercontent.com/6286474/106528557-3ab48a00-64e9-11eb-87b8-1e5003ca4009.png)
![qt_iso1_1_iso2_1](https://user-images.githubusercontent.com/6286474/106528562-3be5b700-64e9-11eb-8d76-6008cab2b0fa.png)
![y_iso1_1_iso2_1](https://user-images.githubusercontent.com/6286474/106528566-3daf7a80-64e9-11eb-810a-375789ac113e.png)
