### PR TITLE
Switch to samples with met computed with jec

### DIFF
--- a/Common/data/samples_2016_ulV2.py
+++ b/Common/data/samples_2016_ulV2.py
@@ -1,0 +1,167 @@
+samplespreVFP = {
+    "data": {
+        "nsyst": 0, 
+        "xsec": -1, 
+        "dir": ["Run2016B_preVFP", "Run2016C_preVFP", "Run2016D_preVFP", "Run2016E_preVFP", "Run2016F_preVFP"]
+    },
+    "DYJetsToMuMu_M50": {
+        "nsyst": 2, 
+        "xsec": 1976.17, 
+        "dir": ["DYJetsToMuMu_preVFP0", "DYJetsToMuMu_preVFP1","DYJetsToMuMu_preVFP2","DYJetsToMuMu_preVFP3"]
+    }, 
+    "DYJetsToTauTau_M50": {
+        "nsyst": 2, 
+        "xsec": 0.5802*1976.17, 
+        "dir": ["DYJetsToTauTau_preVFP0","DYJetsToTauTau_preVFP1"]
+    }, 
+    "WPlusJetsToMuNu": {
+        "nsyst": 2, 
+        "xsec": 11572.19, 
+        "dir": ["WPlusToMuNu_preVFP0", "WPlusToMuNu_preVFP1"]
+    },
+    #"WMinusJetsToMuNu": {
+    #    "nsyst": 2, 
+    #    "xsec": 8562.66, 
+    #    "dir": ["WminusJetsToMuNu"]
+    #},
+    "WPlusJetsToTauNu": {
+        "nsyst": 2, 
+        "xsec": 0.17394*11572.19, 
+        "dir": ["WPlusToTauNu_preVFP0"]
+    },
+    #"WMinusJetsToTauNu": {
+    #    "nsyst": 2, 
+    #    "xsec": 0.17394*8562.66, 
+    #    "dir": ["WminusJetsToTauNu"]
+    #},
+    "WZ": {
+        "nsyst": 1,  
+        "xsec": 27.6, 
+        "dir": ["WZ_TuneCP5_13TeV-pythia8"]
+    }, 
+    "WW": {
+        "nsyst": 1,  
+        "xsec": 75.8, 
+        "dir": ["WW_TuneCP5_13TeV-pythia8"]
+    }, 
+    "ST_t-channel_top_5f_InclusiveDecays": {
+        "nsyst": 1,  
+        "xsec": 119.71, 
+        "dir": ["ST_t-channel_top_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8"]
+    }, 
+    "ST_t-channel_tauDecays": {
+        "nsyst": 1,  
+        "xsec": 25.2, 
+        "dir": ["ST_t-channel_tauDecays_TuneCP5_13TeV-comphep-pythia8"]
+    }, 
+    "ST_t-channel_muDecays": {
+        "nsyst": 1,  
+        "xsec": 25.86, 
+        "dir": ["ST_t-channel_muDecays_TuneCP5_13TeV-comphep-pythia8"]
+    }, 
+    "ST_s-channel_4f_leptonDecays": {
+        "nsyst": 1,  
+        "xsec": 3.74, 
+        "dir": ["ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8"]
+    }, 
+    "TTToSemiLeptonic": {
+        "nsyst": 1,  
+        "xsec": 365.34, 
+        "dir": ["TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8"]
+    }, 
+    "TTTo2L2Nu": {
+        "nsyst": 1,  
+        "xsec": 88.29, 
+        "dir": ["TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8"]
+    }, 
+    # "DYJetsToLL_M50_NLO": {
+    #     "nsyst": 1, 
+    #     "xsec": 7181.0, 
+    #     "dir": ["alternate/DYJetsToLL-M50"]
+    # }, 
+    # "WJetsToLNu_NLO": {
+    #     "nsyst": 1, 
+    #     "xsec": 60890.0, 
+    #     "dir": ["alternate/WJetsToLNu_madgraph"]
+    # },
+}
+
+samplespostVFP = {
+    "data": {
+        "nsyst": 0, 
+        "xsec": -1, 
+        "dir": ["Run2016F_postVFP", "Run2016G_postVFP", "Run2016H_postVFP"]
+    },
+    "DYJetsToMuMu_M50": {
+        "nsyst": 2, 
+        "xsec": 1976.17, 
+        "dir": ["DYJetsToMuMu_postVFP0", "DYJetsToMuMu_postVFP1", "DYJetsToMuMu_postVFP2"]
+    }, 
+    "DYJetsToTauTau_M50": {
+        "nsyst": 2, 
+        "xsec": 0.5802*1976.17, 
+        "dir": ["DYJetsToTauTau_postVFP0", "DYJetsToTauTau_postVFP1"]
+    }, 
+    "WPlusJetsToMuNu": {
+        "nsyst": 2, 
+        "xsec": 11572.19, 
+        "dir": ["WPlusToMuNu_postVFP0", "WPlusToMuNu_postVFP1"]
+    },
+    #"WMinusJetsToMuNu": {
+    #    "nsyst": 2, 
+    #    "xsec": 8562.66, 
+    #    "dir": ["WminusJetsToMuNu"]
+    #},
+    "WPlusJetsToTauNu": {
+        "nsyst": 2, 
+        "xsec": 0.17394*11572.19, 
+        "dir": ["WPlusToTauNu_postVFP0"]
+    },
+   # "WMinusJetsToTauNu": {
+   #     "nsyst": 2, 
+   #     "xsec": 0.17394*8562.66, 
+   #     "dir": ["WminusJetsToTauNu"]
+   # },
+    "WZ": {
+        "nsyst": 1,  
+        "xsec": 27.6, 
+        "dir": ["WZ_TuneCP5_13TeV-pythia8"]
+    }, 
+    "WW": {
+        "nsyst": 1,  
+        "xsec": 75.8, 
+        "dir": ["WW_TuneCP5_13TeV-pythia8"]
+    }, 
+    "ST_t-channel_top_5f_InclusiveDecays": {
+        "nsyst": 1,  
+        "xsec": 119.71, 
+        "dir": ["ST_t-channel_top_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8"]
+    }, 
+    "ST_t-channel_tauDecays": {
+        "nsyst": 1,  
+        "xsec": 25.2, 
+        "dir": ["ST_t-channel_tauDecays_TuneCP5_13TeV-comphep-pythia8"]
+    }, 
+    "ST_t-channel_muDecays": {
+        "nsyst": 1,  
+        "xsec": 25.86, 
+        "dir": ["ST_t-channel_muDecays_TuneCP5_13TeV-comphep-pythia8"]
+    }, 
+    "ST_s-channel_4f_leptonDecays": {
+        "nsyst": 1,  
+        "xsec": 3.74, 
+        "dir": ["ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8"]
+    }, 
+    "TTToSemiLeptonic": {
+        "nsyst": 1,  
+        "xsec": 365.34, 
+        "dir": ["TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8"]
+    }, 
+    "TTTo2L2Nu": {
+        "nsyst": 1,  
+        "xsec": 88.29, 
+        "dir": ["TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8"]
+    }, 
+}
+
+

--- a/config/runW_fromNANO.py
+++ b/config/runW_fromNANO.py
@@ -13,7 +13,7 @@ from RDFtree import RDFtree
 
 sys.path.append('{}/Common/data'.format(FWKBASE))
 from genSumW import sumwDictpreVFP, sumwDictpostVFP
-from samples_2016_ulCentral import samplespreVFP, samplespostVFP
+from samples_2016_ulV2 import samplespreVFP, samplespostVFP
 
 ROOT.gSystem.Load('{}/nanotools/bin/libNanoTools.so'.format(FWKBASE))
 sys.path.append('../nanotools')
@@ -43,7 +43,7 @@ def main():
     parser.add_argument('-p', '--pretend',type=bool, default=False, help="run over a small number of event")
     parser.add_argument('-r', '--report',type=bool, default=False, help="Prints the cut flow report for all named filters")
     parser.add_argument('-o', '--outputDir',type=str, default='outputW', help="output dir name")
-    parser.add_argument('-i', '--inputDir',type=str, default='/scratchnvme/wmass/', help="input dir name")    
+    parser.add_argument('-i', '--inputDir',type=str, default='/scratchnvme/wmass/NANOMAY2021/', help="input dir name")    
     parser.add_argument('-e', '--era',type=str, default='preVFP', help="either (preVFP|postVFP)")    
 
     args = parser.parse_args()
@@ -53,7 +53,7 @@ def main():
     era=args.era
     outputDir = args.outputDir+"_"+era
     ##Add era to input dir
-    #inDir+=era
+    inDir+=era
     if pretendJob:
         print("Running a test job over a few events")
     else:

--- a/config/runZ_fromNANO.py
+++ b/config/runZ_fromNANO.py
@@ -12,7 +12,7 @@ sys.path.append('{}/RDFprocessor/framework'.format(FWKBASE))
 from RDFtree import RDFtree
 
 sys.path.append('{}/Common/data'.format(FWKBASE))
-from samples_2016_ul import samplespreVFP, samplespostVFP
+from samples_2016_ulV2 import samplespreVFP, samplespostVFP
 from genSumWClipped import sumwClippedDictpreVFP, sumwClippedDictpostVFP
 
 ROOT.gSystem.Load('{}/nanotools/bin/libNanoTools.so'.format(FWKBASE))
@@ -43,7 +43,7 @@ def main():
     parser.add_argument('-p', '--pretend',type=bool, default=False, help="run over a small number of event")
     parser.add_argument('-r', '--report',type=bool, default=False, help="Prints the cut flow report for all named filters")
     parser.add_argument('-o', '--outputDir',type=str, default='outputDY', help="output dir name")
-    parser.add_argument('-i', '--inputDir',type=str, default='/scratchnvme/wmass/BARENANO/', help="input dir name")    
+    parser.add_argument('-i', '--inputDir',type=str, default='/scratchnvme/wmass/NANOMAY2021/', help="input dir name")    
     parser.add_argument('-e', '--era',type=str, default='preVFP', help="either (preVFP|postVFP)")    
 
     args = parser.parse_args()
@@ -78,7 +78,7 @@ def main():
         xsec = samples[sample]['xsec']
         fvec=ROOT.vector('string')()
         for d in direc:
-            targetDir='{}/{}/merged/'.format(inDir, d)
+            targetDir='{}/{}/'.format(inDir, d)
             for f in os.listdir(targetDir):#check the directory
                 if not f.endswith('.root'): continue
                 inputFile=targetDir+f


### PR DESCRIPTION
Switch to samples with MET computed with JEC applied. This is available for Data, WPlustoMu/TauNu, DY samples only.

runZ_fromNano.py and runW_fromNano.py are working for both eras.