### PR TITLE
Add alternate signal samples

### DIFF
--- a/Common/data/samples_2016_ulV2.py
+++ b/Common/data/samples_2016_ulV2.py
@@ -164,4 +164,28 @@ samplespostVFP = {
     }, 
 }
 
+wsignalNLO_preVFP={
+     "WJetsToLNu_0J": {
+         "nsyst": 1, 
+         "xsec": 60890.0, 
+         "dir": ["WJetsToLNu_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8"]
+     },
+     "WJetsToLNu_1J": {
+         "nsyst": 1, 
+         "xsec": 12790.0, 
+         "dir": ["WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8"]
+     },
+}
 
+wsignalNLO_postVFP={
+     "WJetsToLNu_0J": {
+         "nsyst": 1, 
+         "xsec": 60890.0, 
+         "dir": ["WJetsToLNu_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8"]
+     },
+     "WJetsToLNu_1J": {
+         "nsyst": 1, 
+         "xsec": 12790.0, 
+         "dir": ["WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8"]
+     },
+}


### PR DESCRIPTION
Alternate WJets NLO samples are added to two separate dictionaries for testing purposes. 
Note - these are inclusive samples. XSections are taken from MCM.

https://cms-pdmv.cern.ch/mcm/requests?prepid=SMP-RunIISummer20UL16wmLHEGEN-00056&page=0&shown=2097279

https://cms-pdmv.cern.ch/mcm/requests?dataset_name=WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8&member_of_campaign=RunIISummer20UL16*GEN&page=0&shown=2097279